### PR TITLE
Change nuget artifactory url

### DIFF
--- a/.github/workflows/chapter-3-package-workflow.yml
+++ b/.github/workflows/chapter-3-package-workflow.yml
@@ -72,7 +72,7 @@ jobs:
           dotnet pack Fitnet.Common.IntegrationTestsToolbox/Fitnet.Common.IntegrationTestsToolbox.csproj -c Release
 
       - name: Prepare Packages
-        run: dotnet nuget add source --username $OWNER --password $GITHUB_TOKEN --store-password-in-clear-text --name github "https://nuget.pkg.github.com/$OWNER/index.json"
+        run: dotnet nuget add source --username $OWNER --password $GITHUB_TOKEN --store-password-in-clear-text --name github "https://nuget.pkg.github.com/evolutionary-architecture/index.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Build.props
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Build.props
@@ -9,7 +9,7 @@
         <Nullable>enable</Nullable>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <RepositoryUrl>https://github.com/evolutionary-architecture/evolutionary-architecture-by-example</RepositoryUrl>
-        <Version>1.1.4</Version>
+        <Version>1.1.5</Version>
     </PropertyGroup>
     
     <ItemGroup>


### PR DESCRIPTION
This PR includes work related to migration from our private repo to organisational one. Therefore, artifactory url changed to organisational one and we have to trigger package creation to have at least one version of a package here.

Migration of chapters to the new packages will occur in the next branch (at the moment they refer old repo url)