### PR TITLE
Adjust packages versions in modular monolith

### DIFF
--- a/.github/workflows/chapter-3-contracts-package-workflow.yml
+++ b/.github/workflows/chapter-3-contracts-package-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         dotnet-version: 7.0.x
     - name: Add GitHub NuGet Source
       run: |
-        dotnet nuget add source --username $OWNER --password $GITHUB_TOKEN --store-password-in-clear-text --name github "https://nuget.pkg.github.com/evolutionary-architecture/index.json"
+        dotnet nuget add source --username $OWNER --password $GITHUB_TOKEN --store-password-in-clear-text --name github "https://nuget.pkg.github.com/$OWNER/index.json"
         dotnet nuget list source
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
       with:
         dotnet-version: 7.0.x
     - name: Prepare Packages
-      run: dotnet nuget add source --username $OWNER --password $GITHUB_TOKEN --store-password-in-clear-text --name github "https://nuget.pkg.github.com/evolutionary-architecture/index.json"
+      run: dotnet nuget add source --username $OWNER --password $GITHUB_TOKEN --store-password-in-clear-text --name github "https://nuget.pkg.github.com/$OWNER/index.json"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/chapter-3-package-workflow.yml
+++ b/.github/workflows/chapter-3-package-workflow.yml
@@ -72,7 +72,7 @@ jobs:
           dotnet pack Fitnet.Common.IntegrationTestsToolbox/Fitnet.Common.IntegrationTestsToolbox.csproj -c Release
 
       - name: Prepare Packages
-        run: dotnet nuget add source --username $OWNER --password $GITHUB_TOKEN --store-password-in-clear-text --name github "https://nuget.pkg.github.com/evolutionary-architecture/index.json"
+        run: dotnet nuget add source --username $OWNER --password $GITHUB_TOKEN --store-password-in-clear-text --name github "https://nuget.pkg.github.com/$OWNER/index.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}

--- a/Chapter-3-microservice-extraction/ModularMonolith/Src/Dockerfile
+++ b/Chapter-3-microservice-extraction/ModularMonolith/Src/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /src
 COPY Directory.Build.props ./
 COPY ["Fitnet/Fitnet.csproj", "Fitnet/"]
 
-RUN dotnet nuget add source --username your_username --password your_personal_access_token --store-password-in-clear-text --name github "https://nuget.pkg.github.com/meaboutsoftware/index.json"
+RUN dotnet nuget add source --username your_username --password your_personal_access_token --store-password-in-clear-text --name github "https://nuget.pkg.github.com/evolutionary-architecture/index.json"
 
 RUN dotnet restore "Fitnet/Fitnet.csproj"
 COPY . .

--- a/Chapter-3-microservice-extraction/ModularMonolith/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
+++ b/Chapter-3-microservice-extraction/ModularMonolith/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
@@ -14,8 +14,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.1.4" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.1.4" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.1.5" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.1.5" />
     </ItemGroup>
 
 </Project>

--- a/Chapter-3-microservice-extraction/ModularMonolith/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/ModularMonolith/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="34.0.2" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.4" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     </ItemGroup>
 

--- a/Chapter-3-microservice-extraction/ModularMonolith/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
+++ b/Chapter-3-microservice-extraction/ModularMonolith/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="1.1.4" />
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.1.4" />
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.2" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="1.1.5" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.1.5" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.10" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/ModularMonolith/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
+++ b/Chapter-3-microservice-extraction/ModularMonolith/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.1.4" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.1.5" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/ModularMonolith/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/ModularMonolith/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
@@ -5,9 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.4" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.4" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.2" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.5" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.5" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     </ItemGroup>
 

--- a/Chapter-3-microservice-extraction/ModularMonolith/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
+++ b/Chapter-3-microservice-extraction/ModularMonolith/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
@@ -4,9 +4,9 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.123" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.4" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.1.4" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.1.4" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.5" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.1.5" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.1.5" />
       <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.10" />
       <PackageReference Include="Npgsql" Version="7.0.4" />
     </ItemGroup>

--- a/Chapter-3-microservice-extraction/ModularMonolith/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/ModularMonolith/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.4" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.2" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.5" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     </ItemGroup>
 


### PR DESCRIPTION
This PR is a follow-up of what was done in 2 last branches - after updating repository urls we had to update as well package versions to the currently existing ones in this repo.

Additionally, 2 workflows were adjusted to use $OWNER (which is the organisation to which repo belongs) instead of hard-coded values.