### PR TITLE
Add info about static code analysis

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -58,9 +58,8 @@ What we do not focus on:
 - Frontend (you can use React, Vue, Angular, Svelte or anything else)
 - Logging (you can use https://serilog.net/[Serilog])
 - Contract testing (you can use https://github.com/pact-foundation/pact-net[Pact Net])
-- Static code analysis (you can use https://github.com/dotnet/roslyn-analyzers[Roslyn Analyzers] and/or https://www.sonarsource.com/products/sonarqube[SonarQube])
 
-so that you get the gist of what we have to share with you.
+so that you get the gist of what we have to share with you. Additionally, static code analysis is enabled in all chapters to help us to keep the code base as clean as possible. It is strongly suggested to use it as well in your production code.
 
 NOTE: Keep in mind that these are our suggestions. In the end you will have to decide for yourself which chapters fit your needs or combine them into one solution.
 
@@ -276,6 +275,7 @@ Application:
 - https://github.com/DapperLib/Dapper[Dapper]
 - https://github.com/dotnet/efcore[Entity Framework]
 - https://github.com/npgsql/npgsql[Npgsql]
+- https://github.com/SonarSource/sonar-dotnet[SonarAnalyzer]
 
 Testing:
 


### PR DESCRIPTION
This PR includes addition of information about static code analysis in our root README. After adding it to each chapter (using standard dotnet rules and those from Sonar Analyzer), we have to describe it.