### PR TITLE
Increase the version due to static code analysis changes

### DIFF
--- a/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Build.props
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Build.props
@@ -12,7 +12,7 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RepositoryUrl>https://github.com/evolutionary-architecture/evolutionary-architecture-by-example</RepositoryUrl>
-        <Version>1.1.5</Version>
+        <Version>1.1.6</Version>
     </PropertyGroup>
     
     <ItemGroup>


### PR DESCRIPTION
This PR fixes the problem with releasing the new version of a package. Due to changes related to static code analysis, we had to increase the version and we did not do that - thanks to it, our pipeline is now red.