### PR TITLE
Replace incorrect links that were navigating to old repo

### DIFF
--- a/Chapter-1-initial-architecture/README.adoc
+++ b/Chapter-1-initial-architecture/README.adoc
@@ -115,11 +115,11 @@ However, it is not a classic division between some API, Service and Data access 
 - Data is divided into schemas, where each module has its own schema
 - Business processes are closed in vertical slices, so all the code needed for e.g. contract signing is closed in a _SignContract_ folder.
 
-You can check how does it look like https://github.com/meaboutsoftware/evolutionary-architecture/tree/main/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract[here].
+You can check how does it look like https://github.com/evolutionary-architecture/evolutionary-architecture-by-example/tree/main/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract[here].
 
 As you can see, there are some business rules, events, endpoint and the request object that is used inside the endpoint. Everything grouped together.
 
-There is some https://github.com/meaboutsoftware/evolutionary-architecture/tree/main/Chapter-1-initial-architecture/Src/Fitnet/Contracts[code] that is reused for each vertical slice (like _PrepareContract_ and _SignedContract_):
+There is some https://github.com/evolutionary-architecture/evolutionary-architecture-by-example/tree/main/Chapter-1-initial-architecture/Src/Fitnet/Contracts[code] that is reused for each vertical slice (like _PrepareContract_ and _SignedContract_):
 
 - there is an entity _Contract_ inside folder _Data_ because it is reused by both business processes
 - there are database migrations and operations for _Contracts_ module


### PR DESCRIPTION
This PR contains the changes to obsolete links in README which were pointing to the old repo