### PR TITLE
Replace result with GetResult

### DIFF
--- a/Chapter-2-modules-separation/Src/Common/Fitnet.Common.Infrastructure/Modules/ModuleAvailabilityChecker.cs
+++ b/Chapter-2-modules-separation/Src/Common/Fitnet.Common.Infrastructure/Modules/ModuleAvailabilityChecker.cs
@@ -11,7 +11,7 @@ public static class ModuleAvailabilityChecker
         var buildServiceProvider = services.BuildServiceProvider();
         var featureManager = buildServiceProvider.GetRequiredService<IFeatureManager>();
 
-        return featureManager.IsEnabledAsync(module).Result;
+        return featureManager.IsEnabledAsync(module).GetAwaiter().GetResult();
     }
 
     public static bool IsModuleEnabled(this IApplicationBuilder applicationBuilder, string module)
@@ -19,6 +19,6 @@ public static class ModuleAvailabilityChecker
         var buildServiceProvider = applicationBuilder.ApplicationServices;
         var featureManager = buildServiceProvider.GetRequiredService<IFeatureManager>();
 
-        return featureManager.IsEnabledAsync(module).Result;
+        return featureManager.IsEnabledAsync(module).GetAwaiter().GetResult();
     }
 }

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Infrastructure/Modules/ModuleAvailabilityChecker.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Infrastructure/Modules/ModuleAvailabilityChecker.cs
@@ -11,7 +11,7 @@ public static class ModuleAvailabilityChecker
         var buildServiceProvider = services.BuildServiceProvider();
         var featureManager = buildServiceProvider.GetRequiredService<IFeatureManager>();
 
-        return featureManager.IsEnabledAsync(module).Result;
+        return featureManager.IsEnabledAsync(module).GetAwaiter().GetResult();
     }
 
     public static bool IsModuleEnabled(this IApplicationBuilder applicationBuilder, string module)
@@ -19,6 +19,6 @@ public static class ModuleAvailabilityChecker
         var buildServiceProvider = applicationBuilder.ApplicationServices;
         var featureManager = buildServiceProvider.GetRequiredService<IFeatureManager>();
 
-        return featureManager.IsEnabledAsync(module).Result;
+        return featureManager.IsEnabledAsync(module).GetAwaiter().GetResult();
     }
 }


### PR DESCRIPTION
This PR contains fix to code where we directly access result in a static method which uses async one. Instead it is recommended to use GetAwaiter().GetResult()