### PR TITLE
Fix: small typo in calculation

### DIFF
--- a/Chapter-1-initial-architecture/README.adoc
+++ b/Chapter-1-initial-architecture/README.adoc
@@ -68,7 +68,7 @@ After discussions with our company, we have several assumptions:
 1. Since we want to go global and there are a lot of gyms that claim they want to use our software, we assume that our application will be used by 500 - 5000 people in the beginning.
 2. Each gym has different opening hours (some are open 12 hours, some 16 hours and some 24/7).
 3. We only work in Europe, so the time differences are not big.
-4. Each person creates about 100 requests per day, which gives 5000 people * 1000 req/day = 500 000 req/day for all people. We add 25% of the traffic (to be on the safe side), so it will be 500,000 + 125,000 = 625,000 req/day = 7 req/second. Now we know that we do not need a fancy infrastructure to start with for such a load.
+4. Each person creates about 100 requests per day, which gives 5000 people * 100 req/day = 500 000 req/day for all people. We add 25% of the traffic (to be on the safe side), so it will be 500,000 + 125,000 = 625,000 req/day = 7 req/second. Now we know that we do not need a fancy infrastructure to start with for such a load.
 
 NOTE: We will not cover the topic of infrastructure in this repository. The assumptions are marked here to show you that you should also consider the infrastructure, not just the solution structure. The initial calculation (such as 7 req/sec) is simply to take into account your potential traffic - which may be different during the day and at night - and to design the infrastructure architecture with this in mind. Often this is not thought through and we end up with super complicated infrastructure blocks.
 


### PR DESCRIPTION
Removing small typo in the text. `Each person creates about 100 requests per day` so in the calculation we should have 100 instead of 1000. The result was calculated correctly.