### PR TITLE
Fix docker for chapter 3

### DIFF
--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Dockerfile
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Dockerfile
@@ -1,9 +1,9 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY Directory.Build.props ./
 COPY ["Fitnet.Contracts/Fitnet.Contracts.csproj", "Fitnet.Contracts/"]

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Dockerfile
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Dockerfile
@@ -1,9 +1,9 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY Directory.Build.props ./
 COPY ["Fitnet/Fitnet.csproj", "Fitnet/"]

--- a/Chapter-3-microservice-extraction/docker-compose.yml
+++ b/Chapter-3-microservice-extraction/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   fitnet-modular-monolith:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-    build: ./ModularMonolith/Src
+    build: ./Fitnet/Src
     ports:
       - "8080:80"
     depends_on:
@@ -16,7 +16,7 @@ services:
   fitnet-contracts-microservice:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-    build: ./Contracts/Src
+    build: ./Fitnet.Contracts/Src
     ports:
       - "8081:80"
     depends_on:


### PR DESCRIPTION
This PR contains changes to make docker runnable again in chapter 3. Unfortunately, after upgrading our solution to .NET 8 and changing the catalog names, we forgot to update docker files and compose YML.

Changes included:

- Update dotnet in each Docker file
- Change paths in docker-compose