### PR TITLE
fix: get rid of call build service provider multiple times during feature flag resolving

### DIFF
--- a/Chapter-1-initial-architecture/Src/docker-compose.yml
+++ b/Chapter-1-initial-architecture/Src/docker-compose.yml
@@ -13,9 +13,9 @@ services:
 
   postgres:
     image: postgres:14.3
-    container_name: fitnet_postgres
+    container_name: postgres
     ports:
-      - 6032:5432
+      - 5432:5432
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
     healthcheck:

--- a/Chapter-1-initial-architecture/Src/docker-compose.yml
+++ b/Chapter-1-initial-architecture/Src/docker-compose.yml
@@ -13,9 +13,9 @@ services:
 
   postgres:
     image: postgres:14.3
-    container_name: postgres
+    container_name: fitnet_postgres
     ports:
-      - 5432:5432
+      - 6032:5432
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
     healthcheck:

--- a/Chapter-2-modules-separation/Src/Common/Fitnet.Common.Infrastructure/Modules/ModuleAvailabilityChecker.cs
+++ b/Chapter-2-modules-separation/Src/Common/Fitnet.Common.Infrastructure/Modules/ModuleAvailabilityChecker.cs
@@ -28,7 +28,8 @@ public sealed class ModuleAvailabilityChecker : IDisposable
         return new ModuleAvailabilityChecker(featureManager, featureFlagServiceProvider);
     }
 
-    public bool IsModuleEnabled(string module) => _featureManager.IsEnabledAsync(module).GetAwaiter().GetResult();
+    public bool IsModuleEnabled(string module) =>
+        _featureManager.IsEnabledAsync(module).GetAwaiter().GetResult();
 
     private void Dispose(bool disposing)
     {
@@ -43,8 +44,6 @@ public sealed class ModuleAvailabilityChecker : IDisposable
         Dispose(true);
         GC.SuppressFinalize(this);
     }
-
-    ~ModuleAvailabilityChecker() => Dispose(false);
 }
 
 public static class ModuleAvailabilityCheckerExtensions

--- a/Chapter-2-modules-separation/Src/Common/Fitnet.Common.Infrastructure/Modules/ModuleAvailabilityCheckerExtensions.cs
+++ b/Chapter-2-modules-separation/Src/Common/Fitnet.Common.Infrastructure/Modules/ModuleAvailabilityCheckerExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace EvolutionaryArchitecture.Fitnet.Common.Infrastructure.Modules;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FeatureManagement;
+
+public static class ModuleAvailabilityCheckerExtensions
+{
+    public static bool IsModuleEnabled(this IApplicationBuilder applicationBuilder, string module)
+    {
+        using var scope = applicationBuilder.ApplicationServices.CreateScope();
+        var featureManager = scope.ServiceProvider.GetRequiredService<IFeatureManager>();
+
+        var enabled = featureManager.IsEnabledAsync(module).GetAwaiter().GetResult();
+
+        return enabled;
+    }
+}

--- a/Chapter-2-modules-separation/Src/Common/Tests/Fitnet.Common.Infrastructure.IntegrationTests/Fitnet.Common.Infrastructure.IntegrationTests.csproj
+++ b/Chapter-2-modules-separation/Src/Common/Tests/Fitnet.Common.Infrastructure.IntegrationTests/Fitnet.Common.Infrastructure.IntegrationTests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Chapter-2-modules-separation/Src/Contracts/Fitnet.Contracts.Api/ContractsModule.cs
+++ b/Chapter-2-modules-separation/Src/Contracts/Fitnet.Contracts.Api/ContractsModule.cs
@@ -23,10 +23,10 @@ public static class ContractsModule
         app.MapContracts();
     }
 
-    public static IServiceCollection AddContracts(this IServiceCollection services, IConfiguration configuration,
-        string module)
+    public static IServiceCollection AddContracts(this IServiceCollection services, ModuleAvailabilityChecker checker,
+        string module, IConfiguration configuration)
     {
-        if (!services.IsModuleEnabled(module))
+        if (!checker.IsModuleEnabled(module))
         {
             return services;
         }

--- a/Chapter-2-modules-separation/Src/Contracts/Fitnet.Contracts.Api/ContractsModule.cs
+++ b/Chapter-2-modules-separation/Src/Contracts/Fitnet.Contracts.Api/ContractsModule.cs
@@ -23,8 +23,8 @@ public static class ContractsModule
         app.MapContracts();
     }
 
-    public static IServiceCollection AddContracts(this IServiceCollection services, ModuleAvailabilityChecker checker,
-        string module, IConfiguration configuration)
+    public static IServiceCollection AddContracts(this IServiceCollection services,
+        string module, IConfiguration configuration, ModuleAvailabilityChecker checker)
     {
         if (!checker.IsModuleEnabled(module))
         {

--- a/Chapter-2-modules-separation/Src/Fitnet/Modules/Module.cs
+++ b/Chapter-2-modules-separation/Src/Fitnet/Modules/Module.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet;
+namespace EvolutionaryArchitecture.Fitnet.Modules;
 
 internal record Module(string Value)
 {

--- a/Chapter-2-modules-separation/Src/Fitnet/Modules/ModuleRegistry.cs
+++ b/Chapter-2-modules-separation/Src/Fitnet/Modules/ModuleRegistry.cs
@@ -1,0 +1,27 @@
+﻿namespace EvolutionaryArchitecture.Fitnet.Modules;
+
+using EvolutionaryArchitecture.Fitnet.Common.Infrastructure.Modules;
+using Contracts.Api;
+using Offers.Api;
+using Passes.Api;
+using Reports;
+
+internal static class ModuleRegistry
+{
+    internal static void AddModules(this IServiceCollection services, IConfiguration configuration)
+    {
+        using var moduleAvailabilityChecker = ModuleAvailabilityChecker.Build(configuration);
+        services.AddContracts(Module.Contracts, configuration, moduleAvailabilityChecker);
+        services.AddPasses(Module.Passes, configuration, moduleAvailabilityChecker);
+        services.AddOffers(Module.Offers, configuration, moduleAvailabilityChecker);
+        services.AddReports(Module.Reports, moduleAvailabilityChecker);
+    }
+
+    internal static void RegisterModules(this WebApplication app)
+    {
+        app.RegisterContracts(Module.Contracts);
+        app.RegisterPasses(Module.Passes);
+        app.RegisterOffers(Module.Offers);
+        app.RegisterReports(Module.Reports);
+    }
+}

--- a/Chapter-2-modules-separation/Src/Fitnet/Modules/ModulesRegistry.cs
+++ b/Chapter-2-modules-separation/Src/Fitnet/Modules/ModulesRegistry.cs
@@ -6,11 +6,11 @@ using Offers.Api;
 using Passes.Api;
 using Reports;
 
-internal static class ModuleRegistry
+internal static class ModulesRegistry
 {
     internal static void AddModules(this IServiceCollection services, IConfiguration configuration)
     {
-        using var moduleAvailabilityChecker = ModuleAvailabilityChecker.Build(configuration);
+        using var moduleAvailabilityChecker = ModuleAvailabilityChecker.Create(configuration);
         services.AddContracts(Module.Contracts, configuration, moduleAvailabilityChecker);
         services.AddPasses(Module.Passes, configuration, moduleAvailabilityChecker);
         services.AddOffers(Module.Offers, configuration, moduleAvailabilityChecker);

--- a/Chapter-2-modules-separation/Src/Fitnet/Program.cs
+++ b/Chapter-2-modules-separation/Src/Fitnet/Program.cs
@@ -16,14 +16,8 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddSystemClock();
 builder.Services.AddExceptionHandling();
 builder.Services.AddCommonInfrastructure();
-using (var availabilityChecker = ModuleAvailabilityChecker.Create(builder.Configuration))
-{
-    builder.Services.AddContracts(availabilityChecker, Module.Contracts, builder.Configuration);
-    builder.Services.AddPasses(builder.Configuration, Module.Passes, availabilityChecker);
-    builder.Services.AddOffers(builder.Configuration, Module.Offers, availabilityChecker);
-    builder.Services.AddReports(Module.Reports, availabilityChecker);
-}
 
+RegisterModules(builder);
 
 var app = builder.Build();
 
@@ -47,6 +41,15 @@ app.RegisterOffers(Module.Offers);
 app.RegisterReports(Module.Reports);
 
 app.Run();
+
+static void RegisterModules(WebApplicationBuilder webApplicationBuilder)
+{
+    using var moduleAvailabilityChecker = ModuleAvailabilityChecker.Build(webApplicationBuilder.Configuration);
+    webApplicationBuilder.Services.AddContracts(Module.Contracts, webApplicationBuilder.Configuration, moduleAvailabilityChecker);
+    webApplicationBuilder.Services.AddPasses(Module.Passes, webApplicationBuilder.Configuration, moduleAvailabilityChecker);
+    webApplicationBuilder.Services.AddOffers(Module.Offers, webApplicationBuilder.Configuration, moduleAvailabilityChecker);
+    webApplicationBuilder.Services.AddReports(Module.Reports, moduleAvailabilityChecker);
+}
 
 namespace EvolutionaryArchitecture.Fitnet
 {

--- a/Chapter-2-modules-separation/Src/Fitnet/Program.cs
+++ b/Chapter-2-modules-separation/Src/Fitnet/Program.cs
@@ -1,12 +1,7 @@
-using EvolutionaryArchitecture.Fitnet;
 using EvolutionaryArchitecture.Fitnet.Common.Api.ErrorHandling;
 using EvolutionaryArchitecture.Fitnet.Common.Core.SystemClock;
 using EvolutionaryArchitecture.Fitnet.Common.Infrastructure;
-using EvolutionaryArchitecture.Fitnet.Common.Infrastructure.Modules;
-using EvolutionaryArchitecture.Fitnet.Contracts.Api;
-using EvolutionaryArchitecture.Fitnet.Offers.Api;
-using EvolutionaryArchitecture.Fitnet.Passes.Api;
-using EvolutionaryArchitecture.Fitnet.Reports;
+using EvolutionaryArchitecture.Fitnet.Modules;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
@@ -16,8 +11,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddSystemClock();
 builder.Services.AddExceptionHandling();
 builder.Services.AddCommonInfrastructure();
-
-RegisterModules(builder);
+builder.Services.AddModules(builder.Configuration);
 
 var app = builder.Build();
 
@@ -35,21 +29,10 @@ app.UseErrorHandling();
 
 app.MapControllers();
 
-app.RegisterContracts(Module.Contracts);
-app.RegisterPasses(Module.Passes);
-app.RegisterOffers(Module.Offers);
-app.RegisterReports(Module.Reports);
+app.RegisterModules();
 
 app.Run();
 
-static void RegisterModules(WebApplicationBuilder webApplicationBuilder)
-{
-    using var moduleAvailabilityChecker = ModuleAvailabilityChecker.Build(webApplicationBuilder.Configuration);
-    webApplicationBuilder.Services.AddContracts(Module.Contracts, webApplicationBuilder.Configuration, moduleAvailabilityChecker);
-    webApplicationBuilder.Services.AddPasses(Module.Passes, webApplicationBuilder.Configuration, moduleAvailabilityChecker);
-    webApplicationBuilder.Services.AddOffers(Module.Offers, webApplicationBuilder.Configuration, moduleAvailabilityChecker);
-    webApplicationBuilder.Services.AddReports(Module.Reports, moduleAvailabilityChecker);
-}
 
 namespace EvolutionaryArchitecture.Fitnet
 {

--- a/Chapter-2-modules-separation/Src/Fitnet/Program.cs
+++ b/Chapter-2-modules-separation/Src/Fitnet/Program.cs
@@ -2,13 +2,13 @@ using EvolutionaryArchitecture.Fitnet;
 using EvolutionaryArchitecture.Fitnet.Common.Api.ErrorHandling;
 using EvolutionaryArchitecture.Fitnet.Common.Core.SystemClock;
 using EvolutionaryArchitecture.Fitnet.Common.Infrastructure;
+using EvolutionaryArchitecture.Fitnet.Common.Infrastructure.Modules;
 using EvolutionaryArchitecture.Fitnet.Contracts.Api;
 using EvolutionaryArchitecture.Fitnet.Offers.Api;
 using EvolutionaryArchitecture.Fitnet.Passes.Api;
 using EvolutionaryArchitecture.Fitnet.Reports;
 
 var builder = WebApplication.CreateBuilder(args);
-
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -16,10 +16,14 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddSystemClock();
 builder.Services.AddExceptionHandling();
 builder.Services.AddCommonInfrastructure();
-builder.Services.AddContracts(builder.Configuration, Module.Contracts);
-builder.Services.AddPasses(builder.Configuration, Module.Passes);
-builder.Services.AddOffers(builder.Configuration, Module.Offers);
-builder.Services.AddReports(Module.Reports);
+using (var availabilityChecker = ModuleAvailabilityChecker.Create(builder.Configuration))
+{
+    builder.Services.AddContracts(availabilityChecker, Module.Contracts, builder.Configuration);
+    builder.Services.AddPasses(builder.Configuration, Module.Passes, availabilityChecker);
+    builder.Services.AddOffers(builder.Configuration, Module.Offers, availabilityChecker);
+    builder.Services.AddReports(Module.Reports, availabilityChecker);
+}
+
 
 var app = builder.Build();
 

--- a/Chapter-2-modules-separation/Src/Fitnet/appsettings.Development.json
+++ b/Chapter-2-modules-separation/Src/Fitnet/appsettings.Development.json
@@ -7,14 +7,14 @@
   },
   "FeatureManagement": {
     "Contracts": true,
-    "Offers": true,
+    "Offers": false,
     "Passes": true,
     "Reports": true
   },
   "ConnectionStrings": {
-    "Passes": "Host=postgres:5432;Database=fitnet;Username=postgres;Password=mysecretpassword",
-    "Contracts": "Host=postgres:5432;Database=fitnet;Username=postgres;Password=mysecretpassword",
-    "Reports": "Host=postgres:5432;Database=fitnet;Username=postgres;Password=mysecretpassword",
-    "Offers": "Host=postgres:5432;Database=fitnet;Username=postgres;Password=mysecretpassword"
+    "Passes": "Host=localhost:7432;Database=fitnet;Username=postgres;Password=mysecretpassword",
+    "Contracts": "Host=localhost:7432;Database=fitnet;Username=postgres;Password=mysecretpassword",
+    "Reports": "Host=localhost:7432;Database=fitnet;Username=postgres;Password=mysecretpassword",
+    "Offers": "Host=localhost:7432;Database=fitnet;Username=postgres;Password=mysecretpassword"
   }
 }

--- a/Chapter-2-modules-separation/Src/Fitnet/appsettings.Development.json
+++ b/Chapter-2-modules-separation/Src/Fitnet/appsettings.Development.json
@@ -7,14 +7,14 @@
   },
   "FeatureManagement": {
     "Contracts": true,
-    "Offers": false,
+    "Offers": true,
     "Passes": true,
     "Reports": true
   },
   "ConnectionStrings": {
-    "Passes": "Host=localhost:7432;Database=fitnet;Username=postgres;Password=mysecretpassword",
-    "Contracts": "Host=localhost:7432;Database=fitnet;Username=postgres;Password=mysecretpassword",
-    "Reports": "Host=localhost:7432;Database=fitnet;Username=postgres;Password=mysecretpassword",
-    "Offers": "Host=localhost:7432;Database=fitnet;Username=postgres;Password=mysecretpassword"
+    "Passes": "Host=postgres:5432;Database=fitnet;Username=postgres;Password=mysecretpassword",
+    "Contracts": "Host=postgres:5432;Database=fitnet;Username=postgres;Password=mysecretpassword",
+    "Reports": "Host=postgres:5432;Database=fitnet;Username=postgres;Password=mysecretpassword",
+    "Offers": "Host=postgres:5432;Database=fitnet;Username=postgres;Password=mysecretpassword"
   }
 }

--- a/Chapter-2-modules-separation/Src/Offers/Fitnet.Offers.Api/OffersModule.cs
+++ b/Chapter-2-modules-separation/Src/Offers/Fitnet.Offers.Api/OffersModule.cs
@@ -20,8 +20,9 @@ public static class OffersModule
         app.UseOffers();
     }
 
-    public static IServiceCollection AddOffers(this IServiceCollection services, IConfiguration configuration,
-        string module, ModuleAvailabilityChecker moduleAvailabilityChecker)
+    public static IServiceCollection AddOffers(this IServiceCollection services,
+        string module, IConfiguration configuration,
+        ModuleAvailabilityChecker moduleAvailabilityChecker)
     {
         if (!moduleAvailabilityChecker.IsModuleEnabled(module))
         {

--- a/Chapter-2-modules-separation/Src/Offers/Fitnet.Offers.Api/OffersModule.cs
+++ b/Chapter-2-modules-separation/Src/Offers/Fitnet.Offers.Api/OffersModule.cs
@@ -21,7 +21,8 @@ public static class OffersModule
     }
 
     public static IServiceCollection AddOffers(this IServiceCollection services,
-        string module, IConfiguration configuration,
+        string module,
+        IConfiguration configuration,
         ModuleAvailabilityChecker moduleAvailabilityChecker)
     {
         if (!moduleAvailabilityChecker.IsModuleEnabled(module))

--- a/Chapter-2-modules-separation/Src/Offers/Fitnet.Offers.Api/OffersModule.cs
+++ b/Chapter-2-modules-separation/Src/Offers/Fitnet.Offers.Api/OffersModule.cs
@@ -21,9 +21,9 @@ public static class OffersModule
     }
 
     public static IServiceCollection AddOffers(this IServiceCollection services, IConfiguration configuration,
-        string module)
+        string module, ModuleAvailabilityChecker moduleAvailabilityChecker)
     {
-        if (!services.IsModuleEnabled(module))
+        if (!moduleAvailabilityChecker.IsModuleEnabled(module))
         {
             return services;
         }

--- a/Chapter-2-modules-separation/Src/Passes/Fitnet.Passes.Api/PassesModule.cs
+++ b/Chapter-2-modules-separation/Src/Passes/Fitnet.Passes.Api/PassesModule.cs
@@ -22,9 +22,9 @@ public static class PassesModule
     }
 
     public static IServiceCollection AddPasses(this IServiceCollection services, IConfiguration configuration,
-        string module)
+        string module, ModuleAvailabilityChecker availabilityChecker)
     {
-        if (!services.IsModuleEnabled(module))
+        if (!availabilityChecker.IsModuleEnabled(module))
         {
             return services;
         }

--- a/Chapter-2-modules-separation/Src/Passes/Fitnet.Passes.Api/PassesModule.cs
+++ b/Chapter-2-modules-separation/Src/Passes/Fitnet.Passes.Api/PassesModule.cs
@@ -21,8 +21,9 @@ public static class PassesModule
         app.MapPasses();
     }
 
-    public static IServiceCollection AddPasses(this IServiceCollection services, IConfiguration configuration,
-        string module, ModuleAvailabilityChecker availabilityChecker)
+    public static IServiceCollection AddPasses(this IServiceCollection services,
+        string module, IConfiguration configuration,
+        ModuleAvailabilityChecker availabilityChecker)
     {
         if (!availabilityChecker.IsModuleEnabled(module))
         {

--- a/Chapter-2-modules-separation/Src/Reports/Fitnet.Reports/ReportsModule.cs
+++ b/Chapter-2-modules-separation/Src/Reports/Fitnet.Reports/ReportsModule.cs
@@ -19,9 +19,9 @@ public static class ReportsModule
         app.MapReports();
     }
 
-    public static IServiceCollection AddReports(this IServiceCollection services, string module)
+    public static IServiceCollection AddReports(this IServiceCollection services, string module, ModuleAvailabilityChecker availabilityChecker)
     {
-        if (!services.IsModuleEnabled(module))
+        if (!availabilityChecker.IsModuleEnabled(module))
         {
             return services;
         }

--- a/Chapter-2-modules-separation/Src/docker-compose.yml
+++ b/Chapter-2-modules-separation/Src/docker-compose.yml
@@ -13,9 +13,9 @@ services:
 
   postgres:
     image: postgres:14.3
-    container_name: postgres_fitnet_2
+    container_name: postgres
     ports:
-      - 7432:5432
+      - 5432:5432
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
     healthcheck:

--- a/Chapter-2-modules-separation/Src/docker-compose.yml
+++ b/Chapter-2-modules-separation/Src/docker-compose.yml
@@ -13,9 +13,9 @@ services:
 
   postgres:
     image: postgres:14.3
-    container_name: postgres
+    container_name: postgres_fitnet_2
     ports:
-      - 5432:5432
+      - 7432:5432
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
     healthcheck:


### PR DESCRIPTION
**🔧 PR Includes:**

Fixed feature flag resolving mechanism during startup. The previous version used the build service provider on the main dependency injection container, resulting in dependencies being built multiple times, which caused issues in singleton services. (Reference: https://medium.com/@damien.vandekerckhove/why-you-shouldnt-call-buildserviceprovider-in-net-development-8e25f680d529)

The issue arises when the feature flag is resolved in the ServiceCollection part.

**🛠️ Changes Made:**

Implemented a new approach that creates a dedicated service provider, which is disposed of right away when the application's dependencies are registered. This new provider only contains dependencies that are used for feature flag resolution, thus isolating it from causing issues in other dependencies.