### PR TITLE
Use TimeProvider in modular monolith

### DIFF
--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/OfferPrepareEvent.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/OfferPrepareEvent.cs
@@ -4,9 +4,6 @@ using Common.Infrastructure.Events;
 
 internal sealed record OfferPrepareEvent(Guid Id, Guid OfferId, Guid CustomerId, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {
-    private OfferPrepareEvent(Guid offerId, Guid customerId) : this(Guid.NewGuid(), offerId, customerId, DateTimeOffset.Now)
-    {
-    }
-
-    internal static OfferPrepareEvent Create(Guid offerId, Guid customerId) => new(offerId, customerId);
+    internal static OfferPrepareEvent Create(Guid offerId, Guid customerId, DateTimeOffset occurredAt) =>
+        new(Guid.NewGuid(), offerId, customerId, occurredAt);
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/PassExpiredEventConsumer.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/PassExpiredEventConsumer.cs
@@ -17,7 +17,7 @@ internal sealed class PassExpiredEventConsumer(
         persistence.Offers.Add(offer);
         await persistence.SaveChangesAsync(context.CancellationToken);
 
-        var offerPreparedEvent = OfferPrepareEvent.Create(offer.Id, offer.CustomerId);
+        var offerPreparedEvent = OfferPrepareEvent.Create(offer.Id, offer.CustomerId, timeProvider.GetUtcNow());
         await eventBus.Publish(offerPreparedEvent, context.CancellationToken);
     }
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/PassExpiredEventConsumer.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/PassExpiredEventConsumer.cs
@@ -1,6 +1,5 @@
 namespace EvolutionaryArchitecture.Fitnet.Offers.Api.Prepare;
 
-using Common.Core.SystemClock;
 using DataAccess;
 using DataAccess.Database;
 using MassTransit;
@@ -9,12 +8,12 @@ using Passes.IntegrationEvents;
 internal sealed class PassExpiredEventConsumer(
     IPublishEndpoint eventBus,
     OffersPersistence persistence,
-    ISystemClock systemClock) : IConsumer<PassExpiredEvent>
+    TimeProvider timeProvider) : IConsumer<PassExpiredEvent>
 {
     public async Task Consume(ConsumeContext<PassExpiredEvent> context)
     {
         var @event = context.Message;
-        var offer = Offer.PrepareStandardPassExtension(@event.CustomerId, systemClock.Now);
+        var offer = Offer.PrepareStandardPassExtension(@event.CustomerId, timeProvider.GetUtcNow());
         persistence.Offers.Add(offer);
         await persistence.SaveChangesAsync(context.CancellationToken);
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
@@ -2,7 +2,6 @@ namespace EvolutionaryArchitecture.Fitnet.Passes.Api.MarkPassAsExpired;
 
 using IntegrationEvents;
 using DataAccess.Database;
-using Fitnet.Common.Core.SystemClock;
 using MassTransit;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -15,7 +14,7 @@ internal static class MarkPassAsExpiredEndpoint
             async (
                 Guid id,
                 PassesPersistence persistence,
-                ISystemClock systemClock,
+                TimeProvider timeProvider,
                 IPublishEndpoint publishEndpoint,
                 CancellationToken cancellationToken) =>
             {
@@ -25,7 +24,7 @@ internal static class MarkPassAsExpiredEndpoint
                     return Results.NotFound();
                 }
 
-                pass.MarkAsExpired(systemClock.Now);
+                pass.MarkAsExpired(timeProvider.GetUtcNow());
                 await persistence.SaveChangesAsync(cancellationToken);
 
                 var passExpiredEvent = PassExpiredEvent.Create(pass.Id, pass.CustomerId);

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
@@ -27,7 +27,7 @@ internal static class MarkPassAsExpiredEndpoint
                 pass.MarkAsExpired(timeProvider.GetUtcNow());
                 await persistence.SaveChangesAsync(cancellationToken);
 
-                var passExpiredEvent = PassExpiredEvent.Create(pass.Id, pass.CustomerId);
+                var passExpiredEvent = PassExpiredEvent.Create(pass.Id, pass.CustomerId, timeProvider.GetUtcNow());
                 await publishEndpoint.Publish(passExpiredEvent, cancellationToken);
 
                 return Results.NoContent();

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/RegisterPass/ContractSignedEventConsumer.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/RegisterPass/ContractSignedEventConsumer.cs
@@ -5,7 +5,9 @@ using DataAccess;
 using DataAccess.Database;
 using MassTransit;
 
-public sealed class ContractSignedEventConsumer(PassesPersistence persistence) : IConsumer<ContractSignedEvent>
+public sealed class ContractSignedEventConsumer(
+    PassesPersistence persistence,
+    TimeProvider timeProvider) : IConsumer<ContractSignedEvent>
 {
     public async Task Consume(ConsumeContext<ContractSignedEvent> context)
     {
@@ -14,7 +16,7 @@ public sealed class ContractSignedEventConsumer(PassesPersistence persistence) :
         await persistence.Passes.AddAsync(pass, context.CancellationToken);
         await persistence.SaveChangesAsync(context.CancellationToken);
 
-        var passRegisteredEvent = PassRegisteredEvent.Create(pass.Id);
+        var passRegisteredEvent = PassRegisteredEvent.Create(pass.Id, timeProvider.GetUtcNow());
         await context.Publish(passRegisteredEvent, context.CancellationToken);
     }
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/RegisterPass/PassRegisteredEvent.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/RegisterPass/PassRegisteredEvent.cs
@@ -4,6 +4,6 @@ using Fitnet.Common.Infrastructure.Events;
 
 internal record PassRegisteredEvent(Guid Id, Guid PassId, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {
-    internal static PassRegisteredEvent Create(Guid passId) =>
-        new(Guid.NewGuid(), passId, DateTimeOffset.UtcNow);
+    internal static PassRegisteredEvent Create(Guid passId, DateTimeOffset occurredAt) =>
+        new(Guid.NewGuid(), passId, occurredAt);
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/PassExpiredEvent.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/PassExpiredEvent.cs
@@ -5,6 +5,6 @@ using Common.Infrastructure.Events;
 public record PassExpiredEvent
     (Guid Id, Guid PassId, Guid CustomerId, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {
-    public static PassExpiredEvent Create(Guid passId, Guid customerId) =>
-        new(Guid.NewGuid(), passId, customerId, DateTimeOffset.Now);
+    public static PassExpiredEvent Create(Guid passId, Guid customerId, DateTimeOffset occuredAt) =>
+        new(Guid.NewGuid(), passId, customerId, occuredAt);
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Reports/Fitnet.Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/NewPassesRegistrationPerMonthReportDataRetriever.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Reports/Fitnet.Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/NewPassesRegistrationPerMonthReportDataRetriever.cs
@@ -1,13 +1,12 @@
 namespace EvolutionaryArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.DataRetriever;
 
-using Common.Core.SystemClock;
 using Dapper;
 using Dtos;
 using DataAccess;
 
 internal sealed class NewPassesRegistrationPerMonthReportDataRetriever(
         IDatabaseConnectionFactory databaseConnectionFactory,
-        ISystemClock clock) : INewPassesRegistrationPerMonthReportDataRetriever
+        TimeProvider timeProvider) : INewPassesRegistrationPerMonthReportDataRetriever
 {
     public async Task<IReadOnlyCollection<NewPassesRegistrationsPerMonthDto>> GetReportDataAsync(
         CancellationToken cancellationToken = default)
@@ -18,7 +17,7 @@ internal sealed class NewPassesRegistrationPerMonthReportDataRetriever(
                to_char(""Passes"".""From"", 'Month') AS ""{nameof(NewPassesRegistrationsPerMonthDto.MonthName)}"",
                COUNT(*) AS ""{nameof(NewPassesRegistrationsPerMonthDto.RegisteredPasses)}""
         FROM ""Passes"".""Passes""
-        WHERE EXTRACT(YEAR FROM ""Passes"".""From"") = '{clock.Now.Year}'
+        WHERE EXTRACT(YEAR FROM ""Passes"".""From"") = '{timeProvider.GetUtcNow().Year}'
         GROUP BY ""{nameof(NewPassesRegistrationsPerMonthDto.MonthName)}"", ""{nameof(NewPassesRegistrationsPerMonthDto.MonthOrder)}""
         ORDER BY ""{nameof(NewPassesRegistrationsPerMonthDto.MonthOrder)}""";
 


### PR DESCRIPTION
This PR contains changes related to handling date times in modular monolith. Till now, it was a combination of custom ISystemClock (custom interface that we used in .NET 7 but after migration to .NET 8 it is no longer needed as there is a TimeProvider abstraction that is built-in) and direct access of DateTimeOffset.UtcNow or .Now.