### PR TITLE
Fix date time handling in chapter 3

### DIFF
--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Sign/SignContractCommandHandler.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Sign/SignContractCommandHandler.cs
@@ -1,7 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Application.Sign;
 
 using Common.Api.ErrorHandling;
-using Common.Core.SystemClock;
 using Core;
 using IntegrationEvents;
 using MassTransit;
@@ -9,19 +8,20 @@ using MassTransit;
 [UsedImplicitly]
 internal sealed class SignContractCommandHandler(
     IContractsRepository contractsRepository,
-    ISystemClock systemClock,
+    TimeProvider timeProvider,
     IPublishEndpoint publishEndpoint) : IRequestHandler<SignContractCommand>
 {
     public async Task Handle(SignContractCommand command, CancellationToken cancellationToken)
     {
         var contract = await contractsRepository.GetByIdAsync(command.Id, cancellationToken) ??
                        throw new ResourceNotFoundException(command.Id);
-        contract.Sign(command.SignedAt, systemClock.Now);
+        contract.Sign(command.SignedAt, timeProvider.GetUtcNow());
         await contractsRepository.CommitAsync(cancellationToken);
         var @event = ContractSignedEvent.Create(contract.Id,
                                                         contract.CustomerId,
                                                         contract.SignedAt!.Value,
-                                                        contract.ExpiringAt!.Value);
+                                                        contract.ExpiringAt!.Value,
+                                                        timeProvider.GetUtcNow());
         await publishEndpoint.Publish(@event, cancellationToken);
     }
 }

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationEvents/ContractSignedEvent.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationEvents/ContractSignedEvent.cs
@@ -1,7 +1,18 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents;
 
-public sealed record ContractSignedEvent(Guid Id, Guid ContractId, Guid ContractCustomerId, DateTimeOffset SignedAt, DateTimeOffset ExpireAt, DateTimeOffset OccurredDateTime)
+public sealed record ContractSignedEvent(
+    Guid Id,
+    Guid ContractId,
+    Guid ContractCustomerId,
+    DateTimeOffset SignedAt,
+    DateTimeOffset ExpireAt,
+    DateTimeOffset OccurredDateTime)
 {
-    public static ContractSignedEvent Create(Guid contractId, Guid contractCustomerId, DateTimeOffset signedAt, DateTimeOffset expireAt) =>
-        new(Guid.NewGuid(), contractId, contractCustomerId, signedAt, expireAt, DateTimeOffset.UtcNow);
+    public static ContractSignedEvent Create(
+        Guid contractId,
+        Guid contractCustomerId,
+        DateTimeOffset signedAt,
+        DateTimeOffset expireAt,
+        DateTimeOffset occurredAt) =>
+        new(Guid.NewGuid(), contractId, contractCustomerId, signedAt, expireAt, occurredAt);
 }

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Program.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Program.cs
@@ -1,5 +1,4 @@
 using EvolutionaryArchitecture.Fitnet.Common.Api.ErrorHandling;
-using EvolutionaryArchitecture.Fitnet.Common.Core.SystemClock;
 using EvolutionaryArchitecture.Fitnet.Contracts.Api;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,7 +7,6 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.Services.AddSystemClock();
 builder.Services.AddFeatureManagement();
 
 builder.Services.AddContractsApi(builder.Configuration);

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Program.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Program.cs
@@ -1,6 +1,5 @@
 using EvolutionaryArchitecture.Fitnet;
 using EvolutionaryArchitecture.Fitnet.Common.Api.ErrorHandling;
-using EvolutionaryArchitecture.Fitnet.Common.Core.SystemClock;
 using EvolutionaryArchitecture.Fitnet.Offers.Api;
 using EvolutionaryArchitecture.Fitnet.Passes.Api;
 using EvolutionaryArchitecture.Fitnet.Reports;
@@ -11,7 +10,6 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.Services.AddSystemClock();
 builder.Services.AddFeatureManagement();
 
 builder.Services.AddPasses(builder.Configuration, Module.Passes);

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.1.8" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.3.0" />
     </ItemGroup>
 
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/OfferPrepareEvent.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/OfferPrepareEvent.cs
@@ -4,9 +4,6 @@ using Common.Infrastructure.Events;
 
 internal sealed record OfferPrepareEvent(Guid Id, Guid OfferId, Guid CustomerId, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {
-    private OfferPrepareEvent(Guid offerId, Guid customerId) : this(Guid.NewGuid(), offerId, customerId, DateTimeOffset.Now)
-    {
-    }
-
-    internal static OfferPrepareEvent Create(Guid offerId, Guid customerId) => new(offerId, customerId);
+    internal static OfferPrepareEvent Create(Guid offerId, Guid customerId, DateTimeOffset occurredAt) =>
+        new(Guid.NewGuid(), offerId, customerId, occurredAt);
 }

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/PassExpiredEventConsumer.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/PassExpiredEventConsumer.cs
@@ -17,7 +17,7 @@ internal sealed class PassExpiredEventConsumer(
         persistence.Offers.Add(offer);
         await persistence.SaveChangesAsync(context.CancellationToken);
 
-        var offerPreparedEvent = OfferPrepareEvent.Create(offer.Id, offer.CustomerId);
+        var offerPreparedEvent = OfferPrepareEvent.Create(offer.Id, offer.CustomerId, timeProvider.GetUtcNow());
         await eventBus.Publish(offerPreparedEvent, context.CancellationToken);
     }
 }

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/PassExpiredEventConsumer.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Prepare/PassExpiredEventConsumer.cs
@@ -1,6 +1,5 @@
 namespace EvolutionaryArchitecture.Fitnet.Offers.Api.Prepare;
 
-using Common.Core.SystemClock;
 using DataAccess;
 using DataAccess.Database;
 using MassTransit;
@@ -9,12 +8,12 @@ using Passes.IntegrationEvents;
 internal sealed class PassExpiredEventConsumer(
     IPublishEndpoint eventBus,
     OffersPersistence persistence,
-    ISystemClock systemClock) : IConsumer<PassExpiredEvent>
+    TimeProvider timeProvider) : IConsumer<PassExpiredEvent>
 {
     public async Task Consume(ConsumeContext<PassExpiredEvent> context)
     {
         var @event = context.Message;
-        var offer = Offer.PrepareStandardPassExtension(@event.CustomerId, systemClock.Now);
+        var offer = Offer.PrepareStandardPassExtension(@event.CustomerId, timeProvider.GetUtcNow());
         persistence.Offers.Add(offer);
         await persistence.SaveChangesAsync(context.CancellationToken);
 

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="34.0.2" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.8" />
+        <PackageReference Include="Bogus" Version="35.5.0" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>
 

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="1.1.8" />
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.1.8" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="1.3.0" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.3.0" />
     <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.7" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.1.3" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
@@ -15,7 +15,7 @@ internal static class MarkPassAsExpiredEndpoint
             async (
                 Guid id,
                 PassesPersistence persistence,
-                ISystemClock systemClock,
+                TimeProvider timeProvider,
                 IPublishEndpoint publishEndpoint,
                 CancellationToken cancellationToken) =>
             {
@@ -25,7 +25,7 @@ internal static class MarkPassAsExpiredEndpoint
                     return Results.NotFound();
                 }
 
-                pass.MarkAsExpired(systemClock.Now);
+                pass.MarkAsExpired(timeProvider.GetUtcNow());
                 await persistence.SaveChangesAsync(cancellationToken);
 
                 var passExpiredEvent = PassExpiredEvent.Create(pass.Id, pass.CustomerId);

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
@@ -2,7 +2,6 @@ namespace EvolutionaryArchitecture.Fitnet.Passes.Api.MarkPassAsExpired;
 
 using IntegrationEvents;
 using DataAccess.Database;
-using Fitnet.Common.Core.SystemClock;
 using MassTransit;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -28,7 +27,7 @@ internal static class MarkPassAsExpiredEndpoint
                 pass.MarkAsExpired(timeProvider.GetUtcNow());
                 await persistence.SaveChangesAsync(cancellationToken);
 
-                var passExpiredEvent = PassExpiredEvent.Create(pass.Id, pass.CustomerId);
+                var passExpiredEvent = PassExpiredEvent.Create(pass.Id, pass.CustomerId, timeProvider.GetUtcNow());
                 await publishEndpoint.Publish(passExpiredEvent, cancellationToken);
 
                 return Results.NoContent();

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/RegisterPass/ContractSignedEventConsumer.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/RegisterPass/ContractSignedEventConsumer.cs
@@ -5,7 +5,9 @@ using DataAccess;
 using DataAccess.Database;
 using MassTransit;
 
-public sealed class ContractSignedEventConsumer(PassesPersistence persistence) : IConsumer<ContractSignedEvent>
+public sealed class ContractSignedEventConsumer(
+    PassesPersistence persistence,
+    TimeProvider timeProvider) : IConsumer<ContractSignedEvent>
 {
     public async Task Consume(ConsumeContext<ContractSignedEvent> context)
     {
@@ -14,7 +16,7 @@ public sealed class ContractSignedEventConsumer(PassesPersistence persistence) :
         await persistence.Passes.AddAsync(pass, context.CancellationToken);
         await persistence.SaveChangesAsync(context.CancellationToken);
 
-        var passRegisteredEvent = PassRegisteredEvent.Create(pass.Id);
+        var passRegisteredEvent = PassRegisteredEvent.Create(pass.Id, timeProvider.GetUtcNow());
         await context.Publish(passRegisteredEvent, context.CancellationToken);
     }
 }

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/RegisterPass/PassRegisteredEvent.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/RegisterPass/PassRegisteredEvent.cs
@@ -4,6 +4,6 @@ using Fitnet.Common.Infrastructure.Events;
 
 internal record PassRegisteredEvent(Guid Id, Guid PassId, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {
-    internal static PassRegisteredEvent Create(Guid passId) =>
-        new(Guid.NewGuid(), passId, DateTimeOffset.UtcNow);
+    internal static PassRegisteredEvent Create(Guid passId, DateTimeOffset occurredAt) =>
+        new(Guid.NewGuid(), passId, occurredAt);
 }

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
@@ -3,6 +3,6 @@
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.1.8" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.3.0" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/PassExpiredEvent.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/PassExpiredEvent.cs
@@ -5,6 +5,6 @@ using Common.Infrastructure.Events;
 public record PassExpiredEvent
     (Guid Id, Guid PassId, Guid CustomerId, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {
-    public static PassExpiredEvent Create(Guid passId, Guid customerId) =>
-        new(Guid.NewGuid(), passId, customerId, DateTimeOffset.Now);
+    public static PassExpiredEvent Create(Guid passId, Guid customerId, DateTimeOffset occurredAt) =>
+        new(Guid.NewGuid(), passId, customerId, occurredAt);
 }

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.8" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.8" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.3.0" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.3.0" />
         <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
@@ -4,9 +4,9 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.1.24" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.8" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.1.8" />
-      <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="1.1.8" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.3.0" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.3.0" />
+      <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="1.3.0" />
       <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />
       <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
       <PackageReference Include="Npgsql" Version="8.0.1" />

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/NewPassesRegistrationPerMonthReportDataRetriever.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/NewPassesRegistrationPerMonthReportDataRetriever.cs
@@ -1,13 +1,12 @@
 namespace EvolutionaryArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.DataRetriever;
 
-using Common.Core.SystemClock;
 using Dapper;
 using Dtos;
 using DataAccess;
 
 internal sealed class NewPassesRegistrationPerMonthReportDataRetriever(
         IDatabaseConnectionFactory databaseConnectionFactory,
-        ISystemClock clock) : INewPassesRegistrationPerMonthReportDataRetriever
+        TimeProvider timeProvider) : INewPassesRegistrationPerMonthReportDataRetriever
 {
     public async Task<IReadOnlyCollection<NewPassesRegistrationsPerMonthDto>> GetReportDataAsync(
         CancellationToken cancellationToken = default)
@@ -18,7 +17,7 @@ internal sealed class NewPassesRegistrationPerMonthReportDataRetriever(
                to_char(""Passes"".""From"", 'Month') AS ""{nameof(NewPassesRegistrationsPerMonthDto.MonthName)}"",
                COUNT(*) AS ""{nameof(NewPassesRegistrationsPerMonthDto.RegisteredPasses)}""
         FROM ""Passes"".""Passes""
-        WHERE EXTRACT(YEAR FROM ""Passes"".""From"") = '{clock.Now.Year}'
+        WHERE EXTRACT(YEAR FROM ""Passes"".""From"") = '{timeProvider.GetUtcNow().Year}'
         GROUP BY ""{nameof(NewPassesRegistrationsPerMonthDto.MonthName)}"", ""{nameof(NewPassesRegistrationsPerMonthDto.MonthOrder)}""
         ORDER BY ""{nameof(NewPassesRegistrationsPerMonthDto.MonthOrder)}""";
 

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.8" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.3.0" />
         <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/GenerateNewPassesPerMonthReport/GenerateNewPassesPerMonthReportTests.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/GenerateNewPassesPerMonthReport/GenerateNewPassesPerMonthReportTests.cs
@@ -3,6 +3,7 @@ namespace EvolutionaryArchitecture.Fitnet.Reports.IntegrationTests.GenerateNewPa
 using Common.IntegrationTestsToolbox.TestEngine;
 using Common.IntegrationTestsToolbox.TestEngine.Configuration;
 using Common.IntegrationTestsToolbox.TestEngine.EventBus;
+using Common.IntegrationTestsToolbox.TestEngine.SystemClock;
 using EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEngine.Database;
 using GenerateNewPassesRegistrationsPerMonthReport.Dtos;
 using Passes.Api.RegisterPass;
@@ -12,6 +13,7 @@ using TestData;
 [UsesVerify]
 public sealed class GenerateNewPassesPerMonthReportTests : IClassFixture<FitnetWebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
 {
+    private static readonly FakeSystemTimeProvider FakeTimeProvider = new();
     private readonly HttpClient _applicationHttpClient;
     private readonly ITestHarness _testExternalEventBus;
 
@@ -21,7 +23,7 @@ public sealed class GenerateNewPassesPerMonthReportTests : IClassFixture<FitnetW
         var applicationInMemory = applicationInMemoryFactory
             .WithContainerDatabaseConfigured(new ReportsDatabaseConfiguration(database.ConnectionString!))
             .WithTestEventBus(typeof(ContractSignedEventConsumer))
-            .SetFakeSystemClock(ReportTestCases.FakeNowDate);
+            .WithTime(FakeTimeProvider);
         _applicationHttpClient = applicationInMemory.CreateClient();
         _testExternalEventBus = applicationInMemory.GetTestExternalEventBus();
     }


### PR DESCRIPTION
This PR includes changes related to switching custom system clock abstraction (built on .NET 7) with TimeProvider (built-in .NET 8)