### PR TITLE
Include fake time provider in common package

### DIFF
--- a/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Build.props
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Build.props
@@ -12,7 +12,7 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RepositoryUrl>https://github.com/evolutionary-architecture/evolutionary-architecture-by-example</RepositoryUrl>
-        <Version>1.1.9</Version>
+        <Version>3.0.0</Version>
     </PropertyGroup>
     
     <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/GlobalUsings.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/GlobalUsings.cs
@@ -4,3 +4,4 @@ global using Xunit;
 global using Microsoft.AspNetCore.Mvc.Testing;
 global using Microsoft.AspNetCore.Hosting;
 global using Microsoft.Extensions.Configuration;
+global using Bogus;

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Configuration/ConfigurationExtensions.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Configuration/ConfigurationExtensions.cs
@@ -1,12 +1,9 @@
 namespace EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEngine.Configuration;
 
-using Core.SystemClock;
 using Database;
 using Infrastructure.Mediator;
 using MassTransit;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.DependencyInjection;
-using SystemClock;
 
 public static class ConfigurationExtensions
 {
@@ -25,14 +22,6 @@ public static class ConfigurationExtensions
                 webHostBuilder.UseSetting(setting.Key, setting.Value);
             }
         });
-
-    public static WebApplicationFactory<T> SetFakeSystemClock<T>(
-        this WebApplicationFactory<T> webApplicationFactory,
-        DateTimeOffset fakeDateTimeOffset)
-        where T : class =>
-        webApplicationFactory.WithWebHostBuilder(webHostBuilder =>
-            webHostBuilder.ConfigureTestServices(services =>
-                services.AddSingleton<ISystemClock>(new FakeSystemClock(fakeDateTimeOffset))));
 
     public static WebApplicationFactory<T> WithFakeConsumers<T>(
         this WebApplicationFactory<T> webApplicationFactory,

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/SystemClock/FakeSystemClock.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/SystemClock/FakeSystemClock.cs
@@ -1,8 +1,0 @@
-namespace EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEngine.SystemClock;
-
-using Core.SystemClock;
-
-internal sealed class FakeSystemClock(DateTimeOffset fakeDateTimeOffset) : ISystemClock
-{
-    public DateTimeOffset Now { get; } = fakeDateTimeOffset;
-}

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/FakeTimeProvider.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/FakeTimeProvider.cs
@@ -1,0 +1,9 @@
+namespace EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEngine.Time;
+
+[UsedImplicitly]
+public sealed class FakeTimeProvider(DateTimeOffset? now = null) : TimeProvider
+{
+    private DateTimeOffset TimeNowOffset { get; set; } = now ?? new Faker().Date.RecentOffset().UtcDateTime;
+
+    public override DateTimeOffset GetUtcNow() => TimeNowOffset;
+}

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/TimeExtensions.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/TimeExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEngine.Time;
+
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+public static class TimeExtensions
+{
+    public static WebApplicationFactory<T> WithTime<T>(
+        this WebApplicationFactory<T> webApplicationFactory, FakeTimeProvider fakeTimeProvider)
+        where T : class => webApplicationFactory
+        .WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services => services.AddSingleton<TimeProvider>(fakeTimeProvider)));
+}


### PR DESCRIPTION
This PR includes changes related to adding fake implementation of time provider that can be used across all integration tests.

Additionally, the package number is changed in a way that it fits chapter number - till now we had a problem as our packages are in the same repository when 2 chapters can change their content. Our decision was to number packages in chapter 3 as 3.X.X and these from chapter 4 as 4.X.X