### PR TITLE
Register clock and switch tests to time provider

### DIFF
--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Fitnet.Contracts.Application.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Fitnet.Contracts.Application.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.8" />
-    <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="3.1.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="MassTransit.Abstractions" Version="8.1.3" />
     <PackageReference Include="MediatR" Version="12.2.0" />

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Core.UnitTests/Fitnet.Contracts.Core.UnitTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Core.UnitTests/Fitnet.Contracts.Core.UnitTests.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.0.1" />
-        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.1.8" />
+        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.1.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="xunit" Version="2.6.4" />
         <PackageReference Include="xunit.analyzers" Version="1.8.0" />

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Fitnet.Contracts.Core.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Fitnet.Contracts.Core.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.1.8" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.1.0" />
   </ItemGroup>
   
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationEvents/Fitnet.Contracts.IntegrationEvents.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationEvents/Fitnet.Contracts.IntegrationEvents.csproj
@@ -4,6 +4,6 @@
     <Version>1.0.7</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="1.1.8" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/Fitnet.Contracts.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/Fitnet.Contracts.IntegrationTests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.8" />
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.8" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="3.1.0" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Fitnet.Contracts.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Fitnet.Contracts.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="1.1.8" />
+        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.1.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Program.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Program.cs
@@ -1,4 +1,5 @@
 using EvolutionaryArchitecture.Fitnet.Common.Api.ErrorHandling;
+using EvolutionaryArchitecture.Fitnet.Common.Infrastructure.Clock;
 using EvolutionaryArchitecture.Fitnet.Contracts.Api;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -10,6 +11,8 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddFeatureManagement();
 
 builder.Services.AddContractsApi(builder.Configuration);
+
+builder.Services.AddClock();
 
 var app = builder.Build();
 

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Program.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Program.cs
@@ -1,5 +1,6 @@
 using EvolutionaryArchitecture.Fitnet;
 using EvolutionaryArchitecture.Fitnet.Common.Api.ErrorHandling;
+using EvolutionaryArchitecture.Fitnet.Common.Infrastructure.Clock;
 using EvolutionaryArchitecture.Fitnet.Offers.Api;
 using EvolutionaryArchitecture.Fitnet.Passes.Api;
 using EvolutionaryArchitecture.Fitnet.Reports;
@@ -11,6 +12,8 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddFeatureManagement();
+
+builder.Services.AddClock();
 
 builder.Services.AddPasses(builder.Configuration, Module.Passes);
 builder.Services.AddOffers(builder.Configuration, Module.Offers);

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.3.0" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="3.1.0" />
     </ItemGroup>
 
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.5.0" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.3.0" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="3.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>
 

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="1.3.0" />
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.3.0" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.1.0" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.1.0" />
     <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.7" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.1.3" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
@@ -3,6 +3,6 @@
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.3.0" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.3.0" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.3.0" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="3.1.0" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="3.1.0" />
         <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
@@ -4,9 +4,9 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.1.24" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.3.0" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.3.0" />
-      <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="1.3.0" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="3.1.0" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="3.1.0" />
+      <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.1.0" />
       <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />
       <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
       <PackageReference Include="Npgsql" Version="8.0.1" />

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.3.0" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="3.1.0" />
         <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/GenerateNewPassesPerMonthReport/GenerateNewPassesPerMonthReportTests.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/GenerateNewPassesPerMonthReport/GenerateNewPassesPerMonthReportTests.cs
@@ -3,7 +3,7 @@ namespace EvolutionaryArchitecture.Fitnet.Reports.IntegrationTests.GenerateNewPa
 using Common.IntegrationTestsToolbox.TestEngine;
 using Common.IntegrationTestsToolbox.TestEngine.Configuration;
 using Common.IntegrationTestsToolbox.TestEngine.EventBus;
-using Common.IntegrationTestsToolbox.TestEngine.SystemClock;
+using Common.IntegrationTestsToolbox.TestEngine.Time;
 using EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEngine.Database;
 using GenerateNewPassesRegistrationsPerMonthReport.Dtos;
 using Passes.Api.RegisterPass;
@@ -13,7 +13,7 @@ using TestData;
 [UsesVerify]
 public sealed class GenerateNewPassesPerMonthReportTests : IClassFixture<FitnetWebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
 {
-    private static readonly FakeSystemTimeProvider FakeTimeProvider = new();
+    private static readonly FakeTimeProvider FakeTimeProvider = new(ReportTestCases.FakeNowDate);
     private readonly HttpClient _applicationHttpClient;
     private readonly ITestHarness _testExternalEventBus;
 


### PR DESCRIPTION
This PR includes changes related to:

- clock registration (usage of a common package 3.1.0)
- update of common packages to version 3.1.0
- switch to time provider in reports test