### PR TITLE
Missing possibility of passing own date time offset in fake time provider

### DIFF
--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/Directory.Build.props
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/Directory.Build.props
@@ -12,7 +12,7 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RepositoryUrl>https://github.com/evolutionary-architecture/evolutionary-architecture-by-example</RepositoryUrl>
-        <Version>4.0.0</Version>
+        <Version>4.1.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/FakeTimeProvider.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/FakeTimeProvider.cs
@@ -3,9 +3,9 @@ namespace EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEng
 using Bogus;
 
 [UsedImplicitly]
-public sealed class FakeTimeProvider : TimeProvider
+public sealed class FakeTimeProvider(DateTimeOffset? now) : TimeProvider
 {
-    private DateTimeOffset TimeNowOffset { get; set; } = new Faker().Date.RecentOffset().UtcDateTime;
+    private DateTimeOffset TimeNowOffset { get; set; } = now ?? new Faker().Date.RecentOffset().UtcDateTime;
 
     public override DateTimeOffset GetUtcNow() => TimeNowOffset;
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/FakeTimeProvider.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/FakeTimeProvider.cs
@@ -3,7 +3,7 @@ namespace EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEng
 using Bogus;
 
 [UsedImplicitly]
-public sealed class FakeSystemTimeProvider : TimeProvider
+public sealed class FakeTimeProvider : TimeProvider
 {
     private DateTimeOffset TimeNowOffset { get; set; } = new Faker().Date.RecentOffset().UtcDateTime;
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/TimeExtensions.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/Time/TimeExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 public static class TimeExtensions
 {
     public static WebApplicationFactory<T> WithTime<T>(
-        this WebApplicationFactory<T> webApplicationFactory, FakeSystemTimeProvider fakeTimeProvider)
+        this WebApplicationFactory<T> webApplicationFactory, FakeTimeProvider fakeTimeProvider)
         where T : class => webApplicationFactory
         .WithWebHostBuilder(builder =>
             builder.ConfigureTestServices(services => services.AddSingleton<TimeProvider>(fakeTimeProvider)));


### PR DESCRIPTION
This PR contains change that is required to be able to pass own date time offset via constructor to fake time provider.