### PR TITLE
Register clock in chapter 4

### DIFF
--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Fitnet.Contracts.Application.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Fitnet.Contracts.Application.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.2.1" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="4.1.0" />
     <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="MassTransit.Abstractions" Version="8.1.3" />

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/TerminateBindingContract/TerminateBindingContractCommandHandler.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/TerminateBindingContract/TerminateBindingContractCommandHandler.cs
@@ -10,7 +10,7 @@ internal sealed class TerminateBindingContractCommandHandler(
 {
     public async Task Handle(TerminateBindingContractCommand command, CancellationToken cancellationToken)
     {
-        var contract = await bindingContractsRepository.GetByIdAsync(command.Id, cancellationToken) ??
+        var contract = await bindingContractsRepository.GetByContractIdAsync(command.Id, cancellationToken) ??
                        throw new ResourceNotFoundException(command.Id);
         var terminatedAt = timeProvider.GetUtcNow();
         contract.Terminate(terminatedAt);

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core.UnitTests/Fitnet.Contracts.Core.UnitTests.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core.UnitTests/Fitnet.Contracts.Core.UnitTests.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.4.1" />
-        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.2.1" />
+        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="4.1.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="xunit" Version="2.7.0" />
         <PackageReference Include="xunit.analyzers" Version="1.11.0" />

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Fitnet.Contracts.Core.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Fitnet.Contracts.Core.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.2.1" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="4.1.0" />
     <PackageReference Include="EvolutionaryArchitecture.Fitnet.DomainDrivenDesign.BuildingBlocks" Version="1.2.1" />
   </ItemGroup>
   

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/IBindingContractsRepository.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/IBindingContractsRepository.cs
@@ -2,7 +2,7 @@
 
 public interface IBindingContractsRepository
 {
-    Task<BindingContract?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<BindingContract?> GetByContractIdAsync(Guid contractId, CancellationToken cancellationToken = default);
     Task AddAsync(BindingContract bindingContract, CancellationToken cancellationToken = default);
     Task CommitAsync(CancellationToken cancellationToken = default);
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/BindingContractsRepository.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/BindingContractsRepository.cs
@@ -1,11 +1,14 @@
 ﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Repositories;
 
 using Core;
+using Microsoft.EntityFrameworkCore;
 
 internal sealed class BindingContractsRepository(ContractsPersistence persistence) : IBindingContractsRepository
 {
-    public async Task<BindingContract?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
-        await persistence.BindingContracts.FindAsync([new ContractId(id)], cancellationToken);
+    public async Task<BindingContract?> GetByContractIdAsync(Guid contractId,
+        CancellationToken cancellationToken = default) =>
+        await persistence.BindingContracts.Where(bc => bc.ContractId == new ContractId(contractId))
+            .SingleOrDefaultAsync(cancellationToken: cancellationToken);
 
     public async Task AddAsync(BindingContract bindingContract, CancellationToken cancellationToken = default)
     {

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationEvents/Fitnet.Contracts.IntegrationEvents.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationEvents/Fitnet.Contracts.IntegrationEvents.csproj
@@ -4,6 +4,6 @@
     <Version>1.0.7</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="1.2.1" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="4.1.0" />
   </ItemGroup>
 </Project>

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/Fitnet.Contracts.IntegrationTests.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/Fitnet.Contracts.IntegrationTests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.2.1" />
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.2.1" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="4.1.0" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts/Fitnet.Contracts.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts/Fitnet.Contracts.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="1.2.1" />
+        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="4.1.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts/Program.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts/Program.cs
@@ -1,4 +1,5 @@
 using EvolutionaryArchitecture.Fitnet.Common.Api.ErrorHandling;
+using EvolutionaryArchitecture.Fitnet.Common.Infrastructure.Clock;
 using EvolutionaryArchitecture.Fitnet.Contracts.Api;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,6 +9,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddFeatureManagement();
+builder.Services.AddClock();
 
 builder.Services.AddContractsApi(builder.Configuration);
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Fitnet/Program.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Fitnet/Program.cs
@@ -1,6 +1,6 @@
 using EvolutionaryArchitecture.Fitnet;
 using EvolutionaryArchitecture.Fitnet.Common.Api.ErrorHandling;
-using EvolutionaryArchitecture.Fitnet.Common.Core.SystemClock;
+using EvolutionaryArchitecture.Fitnet.Common.Infrastructure.Clock;
 using EvolutionaryArchitecture.Fitnet.Offers.Api;
 using EvolutionaryArchitecture.Fitnet.Passes.Api;
 using EvolutionaryArchitecture.Fitnet.Reports;
@@ -11,8 +11,8 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.Services.AddSystemClock();
 builder.Services.AddFeatureManagement();
+builder.Services.AddClock();
 
 builder.Services.AddPasses(builder.Configuration, Module.Passes);
 builder.Services.AddOffers(builder.Configuration, Module.Offers);

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.1.8" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="4.1.0" />
     </ItemGroup>
 
 </Project>

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
@@ -5,8 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="34.0.2" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.8" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="4.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="1.1.8" />
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="1.1.8" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="4.1.0" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="4.1.0" />
     <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.7" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.1.3" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
@@ -3,6 +3,6 @@
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="1.1.8" />
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="4.1.0" />
   </ItemGroup>
 </Project>

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.8" />
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.8" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="4.1.0" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="4.1.0" />
         <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
@@ -4,9 +4,9 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.1.24" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="1.1.8" />
-      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="1.1.8" />
-      <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="1.1.8" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="4.1.0" />
+      <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="4.1.0" />
+      <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="4.1.0" />
       <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />
       <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
       <PackageReference Include="Npgsql" Version="8.0.1" />

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="1.1.8" />
+        <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="4.1.0" />
         <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     </ItemGroup>

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/GenerateNewPassesPerMonthReport/GenerateNewPassesPerMonthReportTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/GenerateNewPassesPerMonthReport/GenerateNewPassesPerMonthReportTests.cs
@@ -3,6 +3,7 @@ namespace EvolutionaryArchitecture.Fitnet.Reports.IntegrationTests.GenerateNewPa
 using Common.IntegrationTestsToolbox.TestEngine;
 using Common.IntegrationTestsToolbox.TestEngine.Configuration;
 using Common.IntegrationTestsToolbox.TestEngine.EventBus;
+using Common.IntegrationTestsToolbox.TestEngine.Time;
 using EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEngine.Database;
 using GenerateNewPassesRegistrationsPerMonthReport.Dtos;
 using Passes.Api.RegisterPass;
@@ -12,6 +13,7 @@ using TestData;
 [UsesVerify]
 public sealed class GenerateNewPassesPerMonthReportTests : IClassFixture<FitnetWebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
 {
+    private static readonly FakeTimeProvider FakeTimeProvider = new(ReportTestCases.FakeNowDate);
     private readonly HttpClient _applicationHttpClient;
     private readonly ITestHarness _testExternalEventBus;
 
@@ -21,7 +23,7 @@ public sealed class GenerateNewPassesPerMonthReportTests : IClassFixture<FitnetW
         var applicationInMemory = applicationInMemoryFactory
             .WithContainerDatabaseConfigured(new ReportsDatabaseConfiguration(database.ConnectionString!))
             .WithTestEventBus(typeof(ContractSignedEventConsumer))
-            .SetFakeSystemClock(ReportTestCases.FakeNowDate);
+            .WithTime(FakeTimeProvider);
         _applicationHttpClient = applicationInMemory.CreateClient();
         _testExternalEventBus = applicationInMemory.GetTestExternalEventBus();
     }


### PR DESCRIPTION
This PR includes changes related to:

- update packages in monolith and contracts microservice to 4.1.0
- registration of missing clock in both monolith and contracts microservice
- fix of binding contract tests - use contracts id instead of binding contract id