### PR TITLE
Move repository interfaces from .Core project to .Application project

### DIFF
--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/IContractsRepository.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/IContractsRepository.cs
@@ -1,4 +1,6 @@
-namespace EvolutionaryArchitecture.Fitnet.Contracts.Core;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Application;
+
+using Core;
 
 public interface IContractsRepository
 {

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Sign/SignContractCommandHandler.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Sign/SignContractCommandHandler.cs
@@ -1,7 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Application.Sign;
 
 using Common.Api.ErrorHandling;
-using Core;
 using IntegrationEvents;
 using MassTransit;
 

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/ContractsRepository.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/ContractsRepository.cs
@@ -1,5 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Repositories;
 
+using Application;
 using Core;
 using Microsoft.EntityFrameworkCore;
 

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/RepositoriesModule.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/RepositoriesModule.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Repositories;
 
-using Core;
+using Application;
 using Microsoft.Extensions.DependencyInjection;
 
 internal static class RepositoriesModule

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/IBindingContractsRepository.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/IBindingContractsRepository.cs
@@ -1,4 +1,6 @@
-﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.Core;
+﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.Application;
+
+using Core;
 
 public interface IBindingContractsRepository
 {

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/IContractsRepository.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/IContractsRepository.cs
@@ -1,4 +1,6 @@
-namespace EvolutionaryArchitecture.Fitnet.Contracts.Core;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Application;
+
+using Core;
 
 public interface IContractsRepository
 {

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/SignContract/SignContractCommandHandler.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/SignContract/SignContractCommandHandler.cs
@@ -1,7 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Application.SignContract;
 
 using Common.Api.ErrorHandling;
-using Core;
 using IntegrationEvents;
 using MassTransit;
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/TerminateBindingContract/TerminateBindingContractCommandHandler.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/TerminateBindingContract/TerminateBindingContractCommandHandler.cs
@@ -1,7 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Application.TerminateBindingContract;
 
 using Common.Api.ErrorHandling;
-using Core;
 
 [UsedImplicitly]
 internal sealed class TerminateBindingContractCommandHandler(

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/BindingContractsRepository.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/BindingContractsRepository.cs
@@ -1,5 +1,6 @@
 ﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Repositories;
 
+using Application;
 using Core;
 using Microsoft.EntityFrameworkCore;
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/ContractsRepository.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/ContractsRepository.cs
@@ -1,5 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Repositories;
 
+using Application;
 using Core;
 using Microsoft.EntityFrameworkCore;
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/RepositoriesModule.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Repositories/RepositoriesModule.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Repositories;
 
-using Core;
+using Application;
 using Microsoft.Extensions.DependencyInjection;
 
 internal static class RepositoriesModule


### PR DESCRIPTION
Addresses repository interfaces residing in .Core project for chapter 3 & 4 and moves them to .Application project.