### PR TITLE
Register annexes

### DIFF
--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Annex.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Annex.cs
@@ -9,6 +9,9 @@ public sealed class Annex : Entity
     public BindingContractId BindingContractId { get; init; }
     public DateTimeOffset ValidFrom { get; init; }
 
+    // EF needs this constructor to create non-primitive types
+    private Annex() { }
+
     private Annex(BindingContractId bindingContractId, DateTimeOffset validFrom)
     {
         Id = AnnexId.Create();

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Annex.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Annex.cs
@@ -22,7 +22,7 @@ public sealed class Annex : Entity
         RecordEvent(@event);
     }
 
-    internal static Annex Add(BindingContractId bindingContractId, DateTimeOffset validFrom) =>
+    internal static Annex Attach(BindingContractId bindingContractId, DateTimeOffset validFrom) =>
         new(bindingContractId, validFrom);
 }
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
@@ -16,7 +16,7 @@ public sealed class BindingContract : Entity
     public DateTimeOffset TerminatedAt { get; set; }
     public DateTimeOffset BindingFrom { get; init; }
     public DateTimeOffset ExpiringAt { get; init; }
-    public ICollection<Annex> RegisteredAnnexes { get; }
+    public ICollection<Annex> AttachedAnnexes { get; }
 
     private BindingContract(
         ContractId contractId,
@@ -31,7 +31,7 @@ public sealed class BindingContract : Entity
         Duration = duration;
         ExpiringAt = expiringAt;
         BindingFrom = bindingFrom;
-        RegisteredAnnexes = [];
+        AttachedAnnexes = [];
 
         var @event = BindingContractStartedEvent.Raise(BindingFrom, ExpiringAt);
         RecordEvent(@event);
@@ -49,7 +49,7 @@ public sealed class BindingContract : Entity
         BusinessRuleValidator.Validate(
             new AnnexCanOnlyBeAddedOnlyBeAddedToActiveBindingContractRule(TerminatedAt, ExpiringAt, now));
 
-        RegisteredAnnexes.Add(Annex.Attach(Id, validFrom));
+        AttachedAnnexes.Add(Annex.Attach(Id, validFrom));
     }
 
     public void Terminate(DateTimeOffset terminatedAt)

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
@@ -44,12 +44,12 @@ public sealed class BindingContract : Entity
         DateTimeOffset bindingFrom,
         DateTimeOffset expiringAt) => new(id, customerId, duration, bindingFrom, expiringAt);
 
-    public void AddAnnex(DateTimeOffset validFrom, DateTimeOffset now)
+    public void AttachAnnex(DateTimeOffset validFrom, DateTimeOffset now)
     {
         BusinessRuleValidator.Validate(
             new AnnexCanOnlyBeAddedOnlyBeAddedToActiveBindingContractRule(TerminatedAt, ExpiringAt, now));
 
-        RegisteredAnnexes.Add(Annex.Add(Id, validFrom));
+        RegisteredAnnexes.Add(Annex.Attach(Id, validFrom));
     }
 
     public void Terminate(DateTimeOffset terminatedAt)

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
@@ -16,6 +16,7 @@ public sealed class BindingContract : Entity
     public DateTimeOffset TerminatedAt { get; set; }
     public DateTimeOffset BindingFrom { get; init; }
     public DateTimeOffset ExpiringAt { get; init; }
+    public ICollection<Annex> RegisteredAnnexes { get; }
 
     private BindingContract(
         ContractId contractId,
@@ -30,6 +31,7 @@ public sealed class BindingContract : Entity
         Duration = duration;
         ExpiringAt = expiringAt;
         BindingFrom = bindingFrom;
+        RegisteredAnnexes = [];
 
         var @event = BindingContractStartedEvent.Raise(BindingFrom, ExpiringAt);
         RecordEvent(@event);
@@ -42,12 +44,12 @@ public sealed class BindingContract : Entity
         DateTimeOffset bindingFrom,
         DateTimeOffset expiringAt) => new(id, customerId, duration, bindingFrom, expiringAt);
 
-    public Annex AddAnnex(DateTimeOffset validFrom, DateTimeOffset now)
+    public void AddAnnex(DateTimeOffset validFrom, DateTimeOffset now)
     {
         BusinessRuleValidator.Validate(
             new AnnexCanOnlyBeAddedOnlyBeAddedToActiveBindingContractRule(TerminatedAt, ExpiringAt, now));
 
-        return Annex.Add(Id, validFrom);
+        RegisteredAnnexes.Add(Annex.Add(Id, validFrom));
     }
 
     public void Terminate(DateTimeOffset terminatedAt)

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
@@ -28,7 +28,7 @@ internal sealed class BindingContractEntityConfiguration : IEntityTypeConfigurat
         builder.Property(contract => contract.BindingFrom).IsRequired();
         builder.Property(contract => contract.ExpiringAt).IsRequired();
 
-        builder.OwnsMany<Annex>(nameof(BindingContract.RegisteredAnnexes), annex =>
+        builder.OwnsMany<Annex>(nameof(BindingContract.AttachedAnnexes), annex =>
         {
             annex.WithOwner().HasForeignKey(a => a.BindingContractId);
             annex.ToTable("Annexes");

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
@@ -27,5 +27,23 @@ internal sealed class BindingContractEntityConfiguration : IEntityTypeConfigurat
         builder.Property(contract => contract.TerminatedAt).IsRequired();
         builder.Property(contract => contract.BindingFrom).IsRequired();
         builder.Property(contract => contract.ExpiringAt).IsRequired();
+
+        builder.OwnsMany<Annex>(nameof(BindingContract.RegisteredAnnexes), annex =>
+        {
+            annex.WithOwner().HasForeignKey(a => a.BindingContractId);
+            annex.ToTable("Annexes");
+            annex
+                .Property(annex => annex.Id)
+                .HasConversion(
+                    id => id.Value,
+                    value => new AnnexId(value));
+            annex.Property(annex => annex.Id).IsRequired();
+            annex.Property(annex => annex.BindingContractId)
+                .HasConversion(
+                    id => id.Value,
+                    value => new BindingContractId(value));
+            annex.Property(annex => annex.BindingContractId).IsRequired();
+            annex.Property(annex => annex.ValidFrom).IsRequired();
+        });
     }
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
@@ -28,25 +28,6 @@ internal sealed class BindingContractEntityConfiguration : IEntityTypeConfigurat
         builder.Property(contract => contract.BindingFrom).IsRequired();
         builder.Property(contract => contract.ExpiringAt).IsRequired();
 
-        ConfigureAttachedAnnexes(builder);
+        builder.RegisterAnnexes();
     }
-
-    private static void ConfigureAttachedAnnexes(EntityTypeBuilder<BindingContract> builder) =>
-        builder.OwnsMany<Annex>(nameof(BindingContract.AttachedAnnexes), annex =>
-        {
-            annex.WithOwner().HasForeignKey(a => a.BindingContractId);
-            annex.ToTable("Annexes");
-            annex
-                .Property(annex => annex.Id)
-                .HasConversion(
-                    id => id.Value,
-                    value => new AnnexId(value));
-            annex.Property(annex => annex.Id).IsRequired();
-            annex.Property(annex => annex.BindingContractId)
-                .HasConversion(
-                    id => id.Value,
-                    value => new BindingContractId(value));
-            annex.Property(annex => annex.BindingContractId).IsRequired();
-            annex.Property(annex => annex.ValidFrom).IsRequired();
-        });
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
@@ -28,6 +28,10 @@ internal sealed class BindingContractEntityConfiguration : IEntityTypeConfigurat
         builder.Property(contract => contract.BindingFrom).IsRequired();
         builder.Property(contract => contract.ExpiringAt).IsRequired();
 
+        ConfigureAttachedAnnexes(builder);
+    }
+
+    private static void ConfigureAttachedAnnexes(EntityTypeBuilder<BindingContract> builder) =>
         builder.OwnsMany<Annex>(nameof(BindingContract.AttachedAnnexes), annex =>
         {
             annex.WithOwner().HasForeignKey(a => a.BindingContractId);
@@ -45,5 +49,4 @@ internal sealed class BindingContractEntityConfiguration : IEntityTypeConfigurat
             annex.Property(annex => annex.BindingContractId).IsRequired();
             annex.Property(annex => annex.ValidFrom).IsRequired();
         });
-    }
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractExtensions.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractExtensions.cs
@@ -1,0 +1,27 @@
+﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Configurations;
+
+using Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+internal static class BindingContractExtensions
+{
+    internal static void RegisterAnnexes(this EntityTypeBuilder<BindingContract> builder) => builder.OwnsMany<Annex>(
+        nameof(BindingContract.AttachedAnnexes), annex =>
+        {
+            annex.WithOwner().HasForeignKey(a => a.BindingContractId);
+            annex.ToTable("Annexes");
+            annex
+                .Property(annex => annex.Id)
+                .HasConversion(
+                    id => id.Value,
+                    value => new AnnexId(value));
+            annex.Property(annex => annex.Id).IsRequired();
+            annex.Property(annex => annex.BindingContractId)
+                .HasConversion(
+                    id => id.Value,
+                    value => new BindingContractId(value));
+            annex.Property(annex => annex.BindingContractId).IsRequired();
+            annex.Property(annex => annex.ValidFrom).IsRequired();
+        });
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240412114229_AddAnnexes.Designer.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240412114229_AddAnnexes.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace EvolutionaryArchitecture.Fitnet.Migrations
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Migrations
 {
     [DbContext(typeof(ContractsPersistence))]
-    partial class ContractsPersistenceModelSnapshot : ModelSnapshot
+    [Migration("20240412114229_AddAnnexes")]
+    partial class AddAnnexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240412114229_AddAnnexes.Designer.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240412114229_AddAnnexes.Designer.cs
@@ -83,7 +83,7 @@ namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Migr
 
             modelBuilder.Entity("EvolutionaryArchitecture.Fitnet.Contracts.Core.BindingContract", b =>
                 {
-                    b.OwnsMany("EvolutionaryArchitecture.Fitnet.Contracts.Core.Annex", "RegisteredAnnexes", b1 =>
+                    b.OwnsMany("EvolutionaryArchitecture.Fitnet.Contracts.Core.Annex", "AttachedAnnexes", b1 =>
                         {
                             b1.Property<Guid>("BindingContractId")
                                 .HasColumnType("uuid");
@@ -102,7 +102,7 @@ namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Migr
                                 .HasForeignKey("BindingContractId");
                         });
 
-                    b.Navigation("RegisteredAnnexes");
+                    b.Navigation("AttachedAnnexes");
                 });
 #pragma warning restore 612, 618
         }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240412114229_AddAnnexes.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240412114229_AddAnnexes.cs
@@ -1,0 +1,37 @@
+﻿#nullable disable
+
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Migrations;
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class AddAnnexes : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder) => migrationBuilder.CreateTable(
+            name: "Annexes",
+            schema: "Contracts",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                BindingContractId = table.Column<Guid>(type: "uuid", nullable: false),
+                ValidFrom = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Annexes", x => new { x.BindingContractId, x.Id });
+                table.ForeignKey(
+                    name: "FK_Annexes_BindingContracts_BindingContractId",
+                    column: x => x.BindingContractId,
+                    principalSchema: "Contracts",
+                    principalTable: "BindingContracts",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder) => migrationBuilder.DropTable(
+            name: "Annexes",
+            schema: "Contracts");
+}


### PR DESCRIPTION
This PR contains changes related to Annexes:

- Add private ctor that is required by EF
- Change return type on Binding contract while adding annex to void
- Add ownership of Annexes to the Binding contract
- Database migration (Binding Contract owns many Annexes)