### PR TITLE
Feature/add api logic for attach annex

### DIFF
--- a/Chapter-4-applying-tactical-domain-driven-design/Docs/Contracts/Api/BindingContracts.http
+++ b/Chapter-4-applying-tactical-domain-driven-design/Docs/Contracts/Api/BindingContracts.http
@@ -2,3 +2,14 @@
 ### Terminate a binding contract
 # @name terminateBindingContract
 PATCH {{baseUrl}}/api/binding-contracts/{{bindingContractId}}
+
+###
+### Attach an annex
+# @name attachAnnex
+POST {{baseUrl}}/api/binding-contracts/{{bindingContractId}}/annexes
+
+Content-Type: application/json
+
+{
+  "validFrom": "2023-05-04T12:00:00.000Z"
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api.UnitTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestValidatorTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api.UnitTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestValidatorTests.cs
@@ -12,7 +12,7 @@ public sealed class AttachAnnexToBindingContractRequestValidatorTests
     internal void Given_attach_annex_request_validation_When_request_is_valid_Then_result_should_have_no_errors()
     {
         // Arrange
-        var request = new AttachAnnexToBindingContractRequest(Guid.NewGuid(), _fakeNow);
+        var request = new AttachAnnexToBindingContractRequest(_fakeNow);
 
         // Act
         var result = _validator.TestValidate(request);
@@ -22,23 +22,10 @@ public sealed class AttachAnnexToBindingContractRequestValidatorTests
     }
 
     [Fact]
-    internal void Given_attach_annex_request_validation_When_binding_contract_id_is_invalid_Then_result_should_have_error()
-    {
-        // Arrange
-        var request = new AttachAnnexToBindingContractRequest(Guid.Empty, _fakeNow);
-
-        // Act
-        var result = _validator.TestValidate(request);
-
-        // Assert
-        result.ShouldHaveValidationErrorFor(r => r.BindingContractId);
-    }
-
-    [Fact]
     internal void Given_attach_annex_request_validation_When_valid_from_is_invalid_Then_result_should_have_error()
     {
         // Arrange
-        var request = new AttachAnnexToBindingContractRequest(Guid.Empty, default);
+        var request = new AttachAnnexToBindingContractRequest(default);
 
         // Act
         var result = _validator.TestValidate(request);

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api.UnitTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestValidatorTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api.UnitTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestValidatorTests.cs
@@ -1,0 +1,49 @@
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Api.UnitTests.AttachAnnexToBindingContract;
+
+using EvolutionaryArchitecture.Fitnet.Contracts.Api.AttachAnnexToBindingContract;
+using FluentValidation.TestHelper;
+
+public sealed class AttachAnnexToBindingContractRequestValidatorTests
+{
+    private readonly AttachAnnexToBindingContractRequestValidator _validator = new();
+    private readonly DateTimeOffset _fakeNow = new Faker().Date.RecentOffset();
+
+    [Fact]
+    internal void Given_attach_annex_request_validation_When_request_is_valid_Then_result_should_have_no_errors()
+    {
+        // Arrange
+        var request = new AttachAnnexToBindingContractRequest(Guid.NewGuid(), _fakeNow);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    internal void Given_attach_annex_request_validation_When_binding_contract_id_is_invalid_Then_result_should_have_error()
+    {
+        // Arrange
+        var request = new AttachAnnexToBindingContractRequest(Guid.Empty, _fakeNow);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.BindingContractId);
+    }
+
+    [Fact]
+    internal void Given_attach_annex_request_validation_When_valid_from_is_invalid_Then_result_should_have_error()
+    {
+        // Arrange
+        var request = new AttachAnnexToBindingContractRequest(Guid.Empty, default);
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(r => r.ValidFrom);
+    }
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api.UnitTests/SignContract/SignContractRequestValidatorTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api.UnitTests/SignContract/SignContractRequestValidatorTests.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Contracts.Api.UnitTests.SignContract.SignContract.RequestValidator;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Api.UnitTests.SignContract;
 
 using EvolutionaryArchitecture.Fitnet.Contracts.Api.SignContract;
 using FluentValidation.TestHelper;

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractEndpoint.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractEndpoint.cs
@@ -1,0 +1,39 @@
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Api.TerminateBindingContract;
+
+using Application;
+using AttachAnnexToBindingContract;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+internal static class AttachAnnexToBindingContractEndpoint
+{
+    internal static void MapAttachAnnexToBindingContract(this IEndpointRouteBuilder app) => app.MapPost(
+            ContractsApiPaths.AttachAnnex, async (
+                Guid id,
+                AttachAnnexToBindingContractRequest request,
+                IContractsModule contractsModule,
+                CancellationToken cancellationToken) =>
+            {
+                var command = request.ToCommand(id);
+                var annexId = await contractsModule.ExecuteCommandAsync(command, cancellationToken);
+
+                return Results.Created($"/{BuildUrl(id, annexId)}", annexId);
+            })
+        .WithOpenApi(operation => new(operation)
+        {
+            Summary = "Attach annex to existing binding contract",
+            Description = "This endpoint is used to attach an annex to an existing binding contract.",
+        })
+        .Produces<string>(StatusCodes.Status201Created)
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status409Conflict)
+        .Produces(StatusCodes.Status500InternalServerError);
+
+    private static string BuildUrl(Guid bindingContractId, Guid annexId)
+    {
+        var annexesPath = ContractsApiPaths.AttachAnnex.Replace("{id}", bindingContractId.ToString());
+
+        return Path.Combine(annexesPath, annexId.ToString());
+    }
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractEndpoint.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractEndpoint.cs
@@ -32,7 +32,7 @@ internal static class AttachAnnexToBindingContractEndpoint
 
     private static string BuildUrl(Guid bindingContractId, Guid annexId)
     {
-        var annexesPath = ContractsApiPaths.AttachAnnex.Replace("{id}", bindingContractId.ToString());
+        var annexesPath = ContractsApiPaths.GetAnnexesPath(bindingContractId.ToString());
 
         return Path.Combine(annexesPath, annexId.ToString());
     }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractEndpoint.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractEndpoint.cs
@@ -32,7 +32,7 @@ internal static class AttachAnnexToBindingContractEndpoint
 
     private static string BuildUrl(Guid bindingContractId, Guid annexId)
     {
-        var annexesPath = ContractsApiPaths.GetAnnexesPath(bindingContractId.ToString());
+        var annexesPath = ContractsApiPaths.GetAnnexesPath(bindingContractId);
 
         return Path.Combine(annexesPath, annexId.ToString());
     }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequest.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequest.cs
@@ -1,0 +1,3 @@
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Api.AttachAnnexToBindingContract;
+
+internal sealed record AttachAnnexToBindingContractRequest(Guid BindingContractId, DateTimeOffset ValidFrom);

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequest.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequest.cs
@@ -1,3 +1,9 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Api.AttachAnnexToBindingContract;
 
-internal sealed record AttachAnnexToBindingContractRequest(Guid BindingContractId, DateTimeOffset ValidFrom);
+using Application.AttachAnnexToBindingContract;
+
+internal sealed record AttachAnnexToBindingContractRequest(DateTimeOffset ValidFrom)
+{
+    internal AttachAnnexToBindingContractCommand ToCommand(Guid bindingContractId) =>
+        new(bindingContractId, ValidFrom);
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestValidator.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestValidator.cs
@@ -4,9 +4,5 @@ using FluentValidation;
 
 internal sealed class AttachAnnexToBindingContractRequestValidator : AbstractValidator<AttachAnnexToBindingContractRequest>
 {
-    public AttachAnnexToBindingContractRequestValidator()
-    {
-        RuleFor(request => request.BindingContractId).NotEmpty();
-        RuleFor(request => request.ValidFrom).NotEmpty();
-    }
+    public AttachAnnexToBindingContractRequestValidator() => RuleFor(request => request.ValidFrom).NotEmpty();
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestValidator.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestValidator.cs
@@ -1,0 +1,12 @@
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Api.AttachAnnexToBindingContract;
+
+using FluentValidation;
+
+internal sealed class AttachAnnexToBindingContractRequestValidator : AbstractValidator<AttachAnnexToBindingContractRequest>
+{
+    public AttachAnnexToBindingContractRequestValidator()
+    {
+        RuleFor(request => request.BindingContractId).NotEmpty();
+        RuleFor(request => request.ValidFrom).NotEmpty();
+    }
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsApiPaths.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsApiPaths.cs
@@ -14,5 +14,9 @@ internal static class ContractsApiPaths
     internal const string Sign = $"{ContractsRootApi}/{{id}}";
     internal const string BindingContracts = BindingContractsApi;
 
-    internal static string GetAnnexesPath(string bindingContractId) => AnnexesApi.Replace("{id}", bindingContractId);
+    internal static string GetPreparedContractPath(Guid contractId) =>
+        Path.Combine(ContractsRootApi, contractId.ToString());
+
+    internal static string GetAnnexesPath(Guid bindingContractId) =>
+        AnnexesApi.Replace("{id}", bindingContractId.ToString());
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsApiPaths.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsApiPaths.cs
@@ -13,4 +13,6 @@ internal static class ContractsApiPaths
     internal const string Prepare = ContractsRootApi;
     internal const string Sign = $"{ContractsRootApi}/{{id}}";
     internal const string BindingContracts = BindingContractsApi;
+
+    internal static string GetAnnexesPath(string bindingContractId) => AnnexesApi.Replace("{id}", bindingContractId);
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsApiPaths.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsApiPaths.cs
@@ -6,8 +6,9 @@ internal static class ContractsApiPaths
 {
     private const string ContractsRootApi = $"{ApiPaths.Root}/contracts";
     private const string BindingContractsApi = $"{ApiPaths.Root}/binding-contracts";
+    private const string AnnexesApi = $"{BindingContractsApi}/{{id}}/annexes";
 
-    internal const string AttachAnnex = $"{BindingContractsApi}/{{id}}/attachAnnex";
+    internal const string AttachAnnex = AnnexesApi;
     internal const string Terminate = $"{BindingContractsApi}/{{id}}/terminate";
     internal const string Prepare = ContractsRootApi;
     internal const string Sign = $"{ContractsRootApi}/{{id}}";

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsApiPaths.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsApiPaths.cs
@@ -7,6 +7,7 @@ internal static class ContractsApiPaths
     private const string ContractsRootApi = $"{ApiPaths.Root}/contracts";
     private const string BindingContractsApi = $"{ApiPaths.Root}/binding-contracts";
 
+    internal const string AttachAnnex = $"{BindingContractsApi}/{{id}}/attachAnnex";
     internal const string Terminate = $"{BindingContractsApi}/{{id}}/terminate";
     internal const string Prepare = ContractsRootApi;
     internal const string Sign = $"{ContractsRootApi}/{{id}}";

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsEndpoints.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/ContractsEndpoints.cs
@@ -12,5 +12,6 @@ internal static class ContractsEndpoints
         app.MapPrepareContract();
         app.MapSignContract();
         app.MapTerminateBindingContract();
+        app.MapAttachAnnexToBindingContract();
     }
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/PrepareContract/PrepareContractEndpoint.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/PrepareContract/PrepareContractEndpoint.cs
@@ -15,7 +15,7 @@ internal static class PrepareContractEndpoint
                 var command = request.ToCommand();
                 var contractId = await contractsModule.ExecuteCommandAsync(command, cancellationToken);
 
-                return Results.Created($"/{ContractsApiPaths.Prepare}/{contractId}", contractId);
+                return Results.Created(ContractsApiPaths.GetPreparedContractPath(contractId), contractId);
             })
         .ValidateRequest<PrepareContractRequest>()
         .WithOpenApi(operation => new(operation)

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/TerminateBindingContract/TerminateBindingContractEndpoint.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Api/TerminateBindingContract/TerminateBindingContractEndpoint.cs
@@ -4,16 +4,17 @@ using Application;
 using EvolutionaryArchitecture.Fitnet.Contracts.Application.TerminateBindingContract;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
 internal static class TerminateBindingContractEndpoint
 {
     internal static void MapTerminateBindingContract(this IEndpointRouteBuilder app) => app.MapPatch(
             ContractsApiPaths.Terminate, async (
-                Guid id,
+                [FromRoute(Name = "id")] Guid bindingContractId,
                 IContractsModule contractsModule, CancellationToken cancellationToken) =>
             {
-                var command = new TerminateBindingContractCommand(id);
+                var command = new TerminateBindingContractCommand(bindingContractId);
                 await contractsModule.ExecuteCommandAsync(command, cancellationToken);
 
                 return Results.NoContent();

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/AttachAnnexToBindingContract/AttachAnnexToBindingContractCommand.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/AttachAnnexToBindingContract/AttachAnnexToBindingContractCommand.cs
@@ -1,3 +1,3 @@
 ﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.Application.AttachAnnexToBindingContract;
 
-public sealed record AttachAnnexToBindingContractCommand(Guid BindingContractId, DateTimeOffset ValidFrom) : ICommand;
+public sealed record AttachAnnexToBindingContractCommand(Guid BindingContractId, DateTimeOffset ValidFrom) : ICommand<Guid>;

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/AttachAnnexToBindingContract/AttachAnnexToBindingContractCommandHandler.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Application/AttachAnnexToBindingContract/AttachAnnexToBindingContractCommandHandler.cs
@@ -5,14 +5,16 @@ using Common.Api.ErrorHandling;
 [UsedImplicitly]
 internal sealed class AttachAnnexToBindingContractCommandHandler(
     IBindingContractsRepository bindingContractsRepository,
-    TimeProvider timeProvider) : IRequestHandler<AttachAnnexToBindingContractCommand>
+    TimeProvider timeProvider) : IRequestHandler<AttachAnnexToBindingContractCommand, Guid>
 {
-    public async Task Handle(AttachAnnexToBindingContractCommand command, CancellationToken cancellationToken)
+    public async Task<Guid> Handle(AttachAnnexToBindingContractCommand command, CancellationToken cancellationToken)
     {
         var bindingContract =
             await bindingContractsRepository.GetByIdAsync(command.BindingContractId, cancellationToken) ??
             throw new ResourceNotFoundException(command.BindingContractId);
-        bindingContract.AttachAnnex(command.ValidFrom, timeProvider.GetUtcNow());
+        var annexId = bindingContract.AttachAnnex(command.ValidFrom, timeProvider.GetUtcNow());
         await bindingContractsRepository.CommitAsync(cancellationToken);
+
+        return annexId.Value;
     }
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
@@ -13,7 +13,7 @@ public sealed class BindingContract : Entity
     public ContractId ContractId { get; init; }
     public Guid CustomerId { get; init; }
     public TimeSpan Duration { get; init; }
-    public DateTimeOffset TerminatedAt { get; set; }
+    public DateTimeOffset? TerminatedAt { get; set; }
     public DateTimeOffset BindingFrom { get; init; }
     public DateTimeOffset ExpiringAt { get; init; }
     public ICollection<Annex> AttachedAnnexes { get; }
@@ -66,7 +66,7 @@ public sealed class BindingContract : Entity
 
         TerminatedAt = terminatedAt;
 
-        var @event = BindingContractTerminatedEvent.Raise(TerminatedAt);
+        var @event = BindingContractTerminatedEvent.Raise(terminatedAt);
         RecordEvent(@event);
     }
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Core/BindingContract.cs
@@ -44,7 +44,7 @@ public sealed class BindingContract : Entity
         DateTimeOffset bindingFrom,
         DateTimeOffset expiringAt) => new(id, customerId, duration, bindingFrom, expiringAt);
 
-    public void AttachAnnex(DateTimeOffset validFrom, DateTimeOffset now)
+    public AnnexId AttachAnnex(DateTimeOffset validFrom, DateTimeOffset now)
     {
         BusinessRuleValidator.Validate(
             new AnnexCanOnlyBeAttachedToActiveBindingContractRule(TerminatedAt, ExpiringAt, now));
@@ -52,7 +52,11 @@ public sealed class BindingContract : Entity
         BusinessRuleValidator.Validate(
             new AnnexCanOnlyStartDuringBindingContractPeriodRule(ExpiringAt, validFrom));
 
-        AttachedAnnexes.Add(Annex.Attach(Id, validFrom));
+        var annex = Annex.Attach(Id, validFrom);
+
+        AttachedAnnexes.Add(annex);
+
+        return annex.Id;
     }
 
     public void Terminate(DateTimeOffset terminatedAt)

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Configurations/BindingContractEntityConfiguration.cs
@@ -24,7 +24,7 @@ internal sealed class BindingContractEntityConfiguration : IEntityTypeConfigurat
         builder.Property(contract => contract.ContractId).IsRequired();
         builder.Property(contract => contract.CustomerId).IsRequired();
         builder.Property(contract => contract.Duration).IsRequired();
-        builder.Property(contract => contract.TerminatedAt).IsRequired();
+        builder.Property(contract => contract.TerminatedAt);
         builder.Property(contract => contract.BindingFrom).IsRequired();
         builder.Property(contract => contract.ExpiringAt).IsRequired();
 

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240507073145_ChangeBindingContractTerminatedAtToNullable.Designer.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240507073145_ChangeBindingContractTerminatedAtToNullable.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace EvolutionaryArchitecture.Fitnet.Migrations
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Migrations
 {
     [DbContext(typeof(ContractsPersistence))]
-    partial class ContractsPersistenceModelSnapshot : ModelSnapshot
+    [Migration("20240507073145_ChangeBindingContractTerminatedAtToNullable")]
+    partial class ChangeBindingContractTerminatedAtToNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240507073145_ChangeBindingContractTerminatedAtToNullable.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Database/Migrations/20240507073145_ChangeBindingContractTerminatedAtToNullable.cs
@@ -1,0 +1,31 @@
+﻿#nullable disable
+
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Infrastructure.Database.Migrations;
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class ChangeBindingContractTerminatedAtToNullable : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder) => migrationBuilder.AlterColumn<DateTimeOffset>(
+            name: "TerminatedAt",
+            schema: "Contracts",
+            table: "BindingContracts",
+            type: "timestamp with time zone",
+            nullable: true,
+            oldClrType: typeof(DateTimeOffset),
+            oldType: "timestamp with time zone");
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder) => migrationBuilder.AlterColumn<DateTimeOffset>(
+            name: "TerminatedAt",
+            schema: "Contracts",
+            table: "BindingContracts",
+            type: "timestamp with time zone",
+            nullable: false,
+            defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+            oldClrType: typeof(DateTimeOffset),
+            oldType: "timestamp with time zone",
+            oldNullable: true);
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestFaker.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractRequestFaker.cs
@@ -1,0 +1,10 @@
+namespace EvolutionaryArchitecture.Fitnet.Contracts.IntegrationTests.AttachAnnexToBindingContract;
+
+using EvolutionaryArchitecture.Fitnet.Contracts.Api.AttachAnnexToBindingContract;
+
+internal sealed class AttachAnnexToBindingContractRequestFaker : Faker<AttachAnnexToBindingContractRequest>
+{
+    internal AttachAnnexToBindingContractRequestFaker(DateTimeOffset? validFrom) => CustomInstantiator(faker =>
+        new AttachAnnexToBindingContractRequest(validFrom ?? faker.Date.RecentOffset().ToUniversalTime())
+    );
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractTests.cs
@@ -29,7 +29,7 @@ public class AttachAnnexToBindingContractTests(
         // Arrange
         var contractId = await _applicationHttpClient.PrepareContractAsync();
         var bindingContractId = await _applicationHttpClient.SignContractAsync(contractId);
-        var annexesPath = ContractsApiPaths.GetAnnexesPath(bindingContractId.ToString());
+        var annexesPath = ContractsApiPaths.GetAnnexesPath(bindingContractId);
         AttachAnnexToBindingContractRequest request =
             new AttachAnnexToBindingContractRequestFaker(FakeSystemTimeProvider.GetUtcNow());
 
@@ -45,7 +45,7 @@ public class AttachAnnexToBindingContractTests(
     {
         // Arrange
         var nonExistingBindingContractId = Guid.NewGuid();
-        var annexesPath = ContractsApiPaths.GetAnnexesPath(nonExistingBindingContractId.ToString());
+        var annexesPath = ContractsApiPaths.GetAnnexesPath(nonExistingBindingContractId);
         AttachAnnexToBindingContractRequest request =
             new AttachAnnexToBindingContractRequestFaker(FakeSystemTimeProvider.GetUtcNow());
 
@@ -65,7 +65,7 @@ public class AttachAnnexToBindingContractTests(
         const int timeSkip = 120;
         FakeSystemTimeProvider.SimulateTimeSkip(timeSkip);
         await _applicationHttpClient.TerminateBindingContractAsync(bindingContractId);
-        var annexesPath = ContractsApiPaths.GetAnnexesPath(bindingContractId.ToString());
+        var annexesPath = ContractsApiPaths.GetAnnexesPath(bindingContractId);
         AttachAnnexToBindingContractRequest request =
             new AttachAnnexToBindingContractRequestFaker(FakeSystemTimeProvider.GetUtcNow());
 
@@ -82,7 +82,7 @@ public class AttachAnnexToBindingContractTests(
         // Arrange
         var contractId = await _applicationHttpClient.PrepareContractAsync();
         var bindingContractId = await _applicationHttpClient.SignContractAsync(contractId);
-        var annexesPath = ContractsApiPaths.GetAnnexesPath(bindingContractId.ToString());
+        var annexesPath = ContractsApiPaths.GetAnnexesPath(bindingContractId);
         const int timeSkip = 367;
         FakeSystemTimeProvider.SimulateTimeSkip(timeSkip);
         AttachAnnexToBindingContractRequest request =

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/AttachAnnexToBindingContract/AttachAnnexToBindingContractTests.cs
@@ -1,0 +1,97 @@
+namespace EvolutionaryArchitecture.Fitnet.Contracts.IntegrationTests.AttachAnnexToBindingContract;
+
+using Api;
+using Api.AttachAnnexToBindingContract;
+using Common.IntegrationTestsToolbox.TestEngine;
+using Common.IntegrationTestsToolbox.TestEngine.Configuration;
+using Fitnet.Common.IntegrationTestsToolbox.TestEngine.Database;
+using Common.IntegrationTestsToolbox.TestEngine.EventBus;
+using Common.IntegrationTestsToolbox.TestEngine.Time;
+using PrepareContract;
+using SignContract;
+using TerminateBindingContract;
+
+public class AttachAnnexToBindingContractTests(FitnetWebApplicationFactory<Program> applicationInMemoryFactory, DatabaseContainer database) : IClassFixture<FitnetWebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
+{
+    private static readonly FakeTimeProvider FakeSystemTimeProvider = new(null);
+    private readonly HttpClient _applicationHttpClient = applicationInMemoryFactory
+        .WithContainerDatabaseConfigured(new ContractsDatabaseConfiguration(database.ConnectionString!))
+        .WithTestEventBus()
+        .WithTime(FakeSystemTimeProvider)
+        .CreateClient();
+
+    [Fact]
+    internal async Task Given_attach_annex_request_for_active_binding_contract_Then_should_return_created()
+    {
+        // Arrange
+        var contractId = await _applicationHttpClient.PrepareContractAsync();
+        var bindingContractId = await _applicationHttpClient.SignContractAsync(contractId);
+        var path = GetUrl(bindingContractId);
+        AttachAnnexToBindingContractRequest request =
+            new AttachAnnexToBindingContractRequestFaker(FakeSystemTimeProvider.GetUtcNow());
+
+        // Act
+        var response = await _applicationHttpClient.PostAsJsonAsync(path, request);
+
+        // Assert
+        response.Should().HaveStatusCode(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    internal async Task Given_attach_annex_request_for_non_existing_binding_contract_Then_should_return_not_found()
+    {
+        // Arrange
+        var nonExistingBindingContractId = Guid.NewGuid();
+        var path = GetUrl(nonExistingBindingContractId);
+        AttachAnnexToBindingContractRequest request =
+            new AttachAnnexToBindingContractRequestFaker(FakeSystemTimeProvider.GetUtcNow());
+
+        // Act
+        var response = await _applicationHttpClient.PostAsJsonAsync(path, request);
+
+        // Assert
+        response.Should().HaveStatusCode(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    internal async Task Given_attach_annex_request_for_terminated_binding_contract_Then_should_return_conflict()
+    {
+        // Arrange
+        var contractId = await _applicationHttpClient.PrepareContractAsync();
+        var bindingContractId = await _applicationHttpClient.SignContractAsync(contractId);
+        const int timeSkip = 120;
+        FakeSystemTimeProvider.SimulateTimeSkip(timeSkip);
+        await _applicationHttpClient.TerminateBindingContractAsync(bindingContractId);
+        var path = GetUrl(bindingContractId);
+        AttachAnnexToBindingContractRequest request =
+            new AttachAnnexToBindingContractRequestFaker(FakeSystemTimeProvider.GetUtcNow());
+
+        // Act
+        var response = await _applicationHttpClient.PostAsJsonAsync(path, request);
+
+        // Assert
+        response.Should().HaveStatusCode(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    internal async Task Given_attach_annex_request_for_inactive_binding_contract_Then_should_return_conflict()
+    {
+        // Arrange
+        var contractId = await _applicationHttpClient.PrepareContractAsync();
+        var bindingContractId = await _applicationHttpClient.SignContractAsync(contractId);
+        var path = GetUrl(bindingContractId);
+        const int timeSkip = 367;
+        FakeSystemTimeProvider.SimulateTimeSkip(timeSkip);
+        AttachAnnexToBindingContractRequest request =
+            new AttachAnnexToBindingContractRequestFaker(FakeSystemTimeProvider.GetUtcNow());
+
+        // Act
+        var response = await _applicationHttpClient.PostAsJsonAsync(path, request);
+
+        // Assert
+        response.Should().HaveStatusCode(HttpStatusCode.Conflict);
+    }
+
+    private static string GetUrl(Guid bindingContractId) =>
+        ContractsApiPaths.AttachAnnex.Replace("{id}", bindingContractId.ToString());
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/PrepareContract/PrepareContractTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/PrepareContract/PrepareContractTests.cs
@@ -18,7 +18,7 @@ public sealed class PrepareContractTests(FitnetWebApplicationFactory<Program> ap
             .CreateClient();
 
     [Fact]
-    internal async Task Given_valid_contract_preparation_request_Then_should_return_created_status_code()
+    internal async Task Given_valid_contract_preparation_request_Then_should_return_created()
     {
         // Arrange
         var requestParameters = PrepareContractRequestParameters.GetValid();
@@ -31,7 +31,7 @@ public sealed class PrepareContractTests(FitnetWebApplicationFactory<Program> ap
     }
 
     [Fact]
-    internal async Task Given_contract_preparation_request_with_invalid_age_Then_should_return_conflict_status_code()
+    internal async Task Given_contract_preparation_request_with_invalid_age_Then_should_return_conflict()
     {
         // Arrange
         var requestParameters = PrepareContractRequestParameters.GetWithInvalidAge();
@@ -52,7 +52,7 @@ public sealed class PrepareContractTests(FitnetWebApplicationFactory<Program> ap
     }
 
     [Fact]
-    internal async Task Given_contract_preparation_request_with_invalid_height_Then_should_return_conflict_status_code()
+    internal async Task Given_contract_preparation_request_with_invalid_height_Then_should_return_conflict()
     {
         // Arrange
         var requestParameters = PrepareContractRequestParameters.GetWithInvalidHeight();
@@ -73,7 +73,8 @@ public sealed class PrepareContractTests(FitnetWebApplicationFactory<Program> ap
     }
 
     [Fact]
-    internal async Task Given_contract_preparation_request_When_contract_for_customer_was_prepared_earlier_and_was_not_signed_yet_Then_should_return_conflict_status_code()
+    internal async Task
+        Given_contract_preparation_request_When_contract_for_customer_was_prepared_earlier_and_was_not_signed_yet_Then_should_return_conflict()
     {
         // Arrange
         var requestParameters = PrepareContractRequestParameters.GetValid();

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/SignContract/SignContractTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/SignContract/SignContractTests.cs
@@ -17,7 +17,7 @@ public sealed class SignContractTests(FitnetWebApplicationFactory<Program> appli
             .CreateClient();
 
     [Fact]
-    internal async Task Given_valid_contract_signature_request_Then_should_return_ok_status_code()
+    internal async Task Given_valid_contract_signature_request_Then_should_return_ok()
     {
         // Arrange
         var preparedContractId = await _applicationHttpClient.PrepareContractAsync();
@@ -49,7 +49,7 @@ public sealed class SignContractTests(FitnetWebApplicationFactory<Program> appli
 
     [Fact]
     internal async Task
-        Given_contract_signature_request_with_invalid_signed_date_Then_should_return_conflict_status_code()
+        Given_contract_signature_request_with_invalid_signed_date_Then_should_return_conflict()
     {
         // Arrange
         var preparedContractId = await _applicationHttpClient.PrepareContractAsync();

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractRequestParameters.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractRequestParameters.cs
@@ -1,0 +1,12 @@
+﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.IntegrationTests.TerminateBindingContract;
+
+using Api;
+
+internal record TerminateBindingContractRequestParameters(string Url)
+{
+    internal static TerminateBindingContractRequestParameters GetValid(Guid bindingContractId) =>
+        new(BuildUrl(bindingContractId));
+
+    private static string BuildUrl(Guid bindingContractId) =>
+        ContractsApiPaths.Terminate.Replace("{id}", bindingContractId.ToString());
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractTestExtensions.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractTestExtensions.cs
@@ -1,15 +1,11 @@
 ﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.IntegrationTests.TerminateBindingContract;
 
-using Api;
-
 internal static class TerminateBindingContractTestExtensions
 {
-    internal static async Task TerminateBindingContractAsync(this HttpClient httpClient, Guid contractId)
+    internal static async Task TerminateBindingContractAsync(this HttpClient httpClient, Guid bindingContractId)
     {
-        var response = await httpClient.PatchAsync(GetUrl(contractId), null);
+        var request = TerminateBindingContractRequestParameters.GetValid(bindingContractId);
+        var response = await httpClient.PatchAsync(request.Url, null);
         response.EnsureSuccessStatusCode();
     }
-
-    internal static string GetUrl(Guid bindingContractId) =>
-        ContractsApiPaths.Terminate.Replace("{id}", bindingContractId.ToString());
 }

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractTestExtensions.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractTestExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.IntegrationTests.TerminateBindingContract;
+
+using Api;
+
+internal static class TerminateBindingContractTestExtensions
+{
+    internal static async Task TerminateBindingContractAsync(this HttpClient httpClient, Guid contractId)
+    {
+        var response = await httpClient.PatchAsync(GetUrl(contractId), null);
+        response.EnsureSuccessStatusCode();
+    }
+
+    internal static string GetUrl(Guid bindingContractId) =>
+        ContractsApiPaths.Terminate.Replace("{id}", bindingContractId.ToString());
+}

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractTests.cs
@@ -28,10 +28,10 @@ public sealed class TerminateBindingContractTests(
     {
         // Arrange
         var nonExistingBindingContractId = Guid.NewGuid();
-        var path = TerminateBindingContractTestExtensions.GetUrl(nonExistingBindingContractId);
+        var request = TerminateBindingContractRequestParameters.GetValid(nonExistingBindingContractId);
 
         // Act
-        var response = await _applicationHttpClient.PatchAsync(path, content: null);
+        var response = await _applicationHttpClient.PatchAsync(request.Url, content: null);
 
         // Assert
         response.Should().HaveStatusCode(HttpStatusCode.NotFound);
@@ -44,12 +44,12 @@ public sealed class TerminateBindingContractTests(
         // Arrange
         var preparedContractId = await _applicationHttpClient.PrepareContractAsync();
         var bindingContractId = await _applicationHttpClient.SignContractAsync(preparedContractId);
-        var path = TerminateBindingContractTestExtensions.GetUrl(bindingContractId);
+        var request = TerminateBindingContractRequestParameters.GetValid(bindingContractId);
         FakeSystemTimeProvider.SimulateTimeSkip(TimeSkip);
 
         // Act
         var terminateContractResponse =
-            await _applicationHttpClient.PatchAsync(path, null);
+            await _applicationHttpClient.PatchAsync(request.Url, null);
 
         // Assert
         terminateContractResponse.Should().HaveStatusCode(HttpStatusCode.NoContent);
@@ -62,11 +62,11 @@ public sealed class TerminateBindingContractTests(
         // Arrange
         var preparedContractId = await _applicationHttpClient.PrepareContractAsync();
         var bindingContractId = await _applicationHttpClient.SignContractAsync(preparedContractId);
-        var path = TerminateBindingContractTestExtensions.GetUrl(bindingContractId);
+        var request = TerminateBindingContractRequestParameters.GetValid(bindingContractId);
 
         // Act
         var terminateContractResponse =
-            await _applicationHttpClient.PatchAsync(path, null);
+            await _applicationHttpClient.PatchAsync(request.Url, null);
 
         // Assert
         terminateContractResponse.Should().HaveStatusCode(HttpStatusCode.Conflict);

--- a/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractTests.cs
+++ b/Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationTests/TerminateBindingContract/TerminateBindingContractTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace EvolutionaryArchitecture.Fitnet.Contracts.IntegrationTests.TerminateBindingContract;
 
-using Api;
 using Common.IntegrationTestsToolbox.TestEngine.Time;
 using EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEngine.Database;
 using Common.IntegrationTestsToolbox.TestEngine;
@@ -29,7 +28,7 @@ public sealed class TerminateBindingContractTests(
     {
         // Arrange
         var nonExistingBindingContractId = Guid.NewGuid();
-        var path = GetUrl(nonExistingBindingContractId);
+        var path = TerminateBindingContractTestExtensions.GetUrl(nonExistingBindingContractId);
 
         // Act
         var response = await _applicationHttpClient.PatchAsync(path, content: null);
@@ -45,7 +44,7 @@ public sealed class TerminateBindingContractTests(
         // Arrange
         var preparedContractId = await _applicationHttpClient.PrepareContractAsync();
         var bindingContractId = await _applicationHttpClient.SignContractAsync(preparedContractId);
-        var path = GetUrl(bindingContractId);
+        var path = TerminateBindingContractTestExtensions.GetUrl(bindingContractId);
         FakeSystemTimeProvider.SimulateTimeSkip(TimeSkip);
 
         // Act
@@ -63,7 +62,7 @@ public sealed class TerminateBindingContractTests(
         // Arrange
         var preparedContractId = await _applicationHttpClient.PrepareContractAsync();
         var bindingContractId = await _applicationHttpClient.SignContractAsync(preparedContractId);
-        var path = GetUrl(bindingContractId);
+        var path = TerminateBindingContractTestExtensions.GetUrl(bindingContractId);
 
         // Act
         var terminateContractResponse =
@@ -72,7 +71,4 @@ public sealed class TerminateBindingContractTests(
         // Assert
         terminateContractResponse.Should().HaveStatusCode(HttpStatusCode.Conflict);
     }
-
-    private static string GetUrl(Guid bindingContractId) =>
-        ContractsApiPaths.Terminate.Replace("{id}", bindingContractId.ToString());
 }


### PR DESCRIPTION
This PR includes changes related to:

- return id of the annex when attached to binding contract
- add command and handler for attachment of annex
- add endpoint for attachment of annex
- cleanup of existing contracts tests to stick to convention (do not include status_code in method descriptions)