### PR TITLE
Define nuget source name as env variable and reuse

### DIFF
--- a/.github/action.yml
+++ b/.github/action.yml
@@ -10,13 +10,15 @@ inputs:
   path:
     description: "Path to the directory"
     required: true
+  nuget-source-name:
+    description: "Name of the Nuget source"
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Add Authorized Evolutionary Architecture Nuget Source
       run: |
         cd ${{ github.workspace }}/${{ inputs.path }}
-        NugetSourceName="evolutionaryArchitecture"
         
         if dotnet nuget list source | grep -q $NugetSourceName; then
           echo "Removing existing nuget source: $NugetSourceName"
@@ -25,6 +27,6 @@ runs:
           echo "Nuget source $NugetSourceName does not exist. Skipping removal."
         fi
 
-        dotnet nuget add source --username ${{ inputs.owner }} --password ${{ inputs.github-token }} --store-password-in-clear-text --name $NugetSourceName "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+        dotnet nuget add source --username ${{ inputs.owner }} --password ${{ inputs.github-token }} --store-password-in-clear-text --name ${{ inputs.nuget-source-name }} "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
         dotnet nuget list source
       shell: bash

--- a/.github/workflows/chapter-4-contracts-workflow.yml
+++ b/.github/workflows/chapter-4-contracts-workflow.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   CHAPTER_DIR: "Chapter-4-applying-tactical-domain-driven-design/Fitnet.Contracts/Src"
+  NUGET_SOURCE_NAME: "evolutionaryArchitecture"
 
 jobs:
   build:
@@ -33,6 +34,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ github.repository_owner }}
           path: ${{ env.CHAPTER_DIR }}
+          nuget-source-name: ${{ env.NUGET_SOURCE_NAME }}
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
@@ -57,6 +59,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ github.repository_owner }}
           path: ${{ env.CHAPTER_DIR }}
+          nuget-source-name: ${{ env.NUGET_SOURCE_NAME }}
       - name: Restore dependencies
         run: dotnet restore
       - name: Test

--- a/.github/workflows/chapter-4-package-workflow.yml
+++ b/.github/workflows/chapter-4-package-workflow.yml
@@ -3,19 +3,19 @@ name: Chapter 4 package workflow
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
-      - 'Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/**'
+      - "Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/**"
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
-      - 'Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/**'
+      - "Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common/**"
 
 env:
-  CHAPTER_DIR: 'Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common'
-  NUGET_SOURCE_NAME: 'evolutionaryArchitecture'
+  CHAPTER_DIR: "Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common"
+  NUGET_SOURCE_NAME: "evolutionaryArchitecture"
 
-jobs: 
+jobs:
   build:
     defaults:
       run:
@@ -32,7 +32,7 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --no-restore
-        
+
   test:
     defaults:
       run:
@@ -51,7 +51,7 @@ jobs:
       - name: Test
         run: dotnet test
 
-  pack: 
+  pack:
     defaults:
       run:
         working-directory: ${{ env.CHAPTER_DIR }}
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
-      
+
       - name: Pack Projects
         run: |
           dotnet pack Fitnet.Common.Api/Fitnet.Common.Api.csproj -c Release
@@ -80,8 +80,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ github.repository_owner }}
           path: ${{ env.CHAPTER_DIR }}
-          nuget: ${{ env.NUGET_SOURCE_NAME }}
-          
+          nuget-source-name: ${{ env.NUGET_SOURCE_NAME }}
+
       - name: Publish Packages
         run: |
           dotnet nuget push "Fitnet.Common.Api/bin/Release/EvolutionaryArchitecture.Fitnet.Common.Api.*.nupkg" --source ${{ env.NUGET_SOURCE_NAME }} --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chapter-4-package-workflow.yml
+++ b/.github/workflows/chapter-4-package-workflow.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CHAPTER_DIR: 'Chapter-4-applying-tactical-domain-driven-design/Fitnet.Common'
+  NUGET_SOURCE_NAME: 'evolutionaryArchitecture'
 
 jobs: 
   build:
@@ -79,11 +80,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ github.repository_owner }}
           path: ${{ env.CHAPTER_DIR }}
+          nuget: ${{ env.NUGET_SOURCE_NAME }}
           
       - name: Publish Packages
         run: |
-          dotnet nuget push "Fitnet.Common.Api/bin/Release/EvolutionaryArchitecture.Fitnet.Common.Api.*.nupkg" --source "github" --api-key ${{ secrets.GITHUB_TOKEN }}
-          dotnet nuget push "Fitnet.Common.Core/bin/Release/EvolutionaryArchitecture.Fitnet.Common.Core.*.nupkg" --source "github" --api-key ${{ secrets.GITHUB_TOKEN }}
-          dotnet nuget push "Fitnet.Common.Infrastructure/bin/Release/EvolutionaryArchitecture.Fitnet.Common.Infrastructure.*.nupkg" --source "github" --api-key ${{ secrets.GITHUB_TOKEN }}
-          dotnet nuget push "Fitnet.Common.IntegrationTestsToolbox/bin/Release/EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.*.nupkg" --source "github" --api-key ${{ secrets.GITHUB_TOKEN }}
-          dotnet nuget push "Fitnet.Common.UnitTesting/bin/Release/EvolutionaryArchitecture.Fitnet.Common.UnitTesting.*.nupkg" --source "github" --api-key ${{ secrets.GITHUB_TOKEN }}
+          dotnet nuget push "Fitnet.Common.Api/bin/Release/EvolutionaryArchitecture.Fitnet.Common.Api.*.nupkg" --source ${{ env.NUGET_SOURCE_NAME }} --api-key ${{ secrets.GITHUB_TOKEN }}
+          dotnet nuget push "Fitnet.Common.Core/bin/Release/EvolutionaryArchitecture.Fitnet.Common.Core.*.nupkg" --source ${{ env.NUGET_SOURCE_NAME }} --api-key ${{ secrets.GITHUB_TOKEN }}
+          dotnet nuget push "Fitnet.Common.Infrastructure/bin/Release/EvolutionaryArchitecture.Fitnet.Common.Infrastructure.*.nupkg" --source ${{ env.NUGET_SOURCE_NAME }} --api-key ${{ secrets.GITHUB_TOKEN }}
+          dotnet nuget push "Fitnet.Common.IntegrationTestsToolbox/bin/Release/EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.*.nupkg" --source ${{ env.NUGET_SOURCE_NAME }} --api-key ${{ secrets.GITHUB_TOKEN }}
+          dotnet nuget push "Fitnet.Common.UnitTesting/bin/Release/EvolutionaryArchitecture.Fitnet.Common.UnitTesting.*.nupkg" --source ${{ env.NUGET_SOURCE_NAME }} --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chapter-4-workflow.yml
+++ b/.github/workflows/chapter-4-workflow.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CHAPTER_DIR: "Chapter-4-applying-tactical-domain-driven-design/Fitnet/Src"
+  NUGET_SOURCE_NAME: "evolutionaryArchitecture"
 
 jobs:
   build:
@@ -34,6 +35,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ github.repository_owner }}
           path: ${{ env.CHAPTER_DIR }}
+          nuget-source-name: ${{ env.NUGET_SOURCE_NAME }}
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
@@ -58,6 +60,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           owner: ${{ github.repository_owner }}
           path: ${{ env.CHAPTER_DIR }}
+          nuget-source-name: ${{ env.NUGET_SOURCE_NAME }}
+
       - name: Restore dependencies
         run: dotnet restore
       - name: Test


### PR DESCRIPTION
## 📋 Description
- This PR fixes the incorrect name of the Nuget source and defines the env variable that can be reused in both action YAML and workflow YAML

## 📦 PR Includes

- [ ] Feature added 🆕
- [X] Bug fix 🐛
- [X] Code refactor 🔄
- [ ] Documentation update 📚
- [ ] Tests added/updated 🧪
- [ ] Other: (describe) 

## 💡 Additional Notes

No additional notes