### PR TITLE
feat: Use FirstOrDefaultAsync for contract retrieval

### DIFF
--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
@@ -37,5 +37,5 @@ internal static class PrepareContractEndpoint
         CancellationToken cancellationToken = default) =>
         await persistence.Contracts
             .OrderByDescending(contract => contract.PreparedAt)
-            .SingleOrDefaultAsync(contract => contract.CustomerId == customerId, cancellationToken);
+            .FirstOrDefaultAsync(contract => contract.CustomerId == customerId, cancellationToken);
 }


### PR DESCRIPTION
Replaces SingleOrDefaultAsync with FirstOrDefaultAsync when fetching contracts by customer ID. This change prevents exceptions if multiple contracts exist for a customer and returns the most recently prepared contract.