### PR TITLE
feat: add central management for nuget packages to chapter 3

### DIFF
--- a/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Packages.props
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Packages.props
@@ -1,0 +1,33 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup Label="Production">
+    <PackageVersion Include="FluentValidation" Version="12.0.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageVersion Include="MassTransit" Version="8.3.2" />
+    <PackageVersion Include="MediatR" Version="12.5.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
+  </ItemGroup>
+  <ItemGroup Label="Tests">
+    <PackageVersion Include="Bogus" Version="35.6.3" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="Testcontainers" Version="4.7.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0" />
+    <PackageVersion Include="Verify.Xunit" Version="30.17.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.analyzers" Version="1.24.0" />
+    <PackageVersion Include="xunit.categories" Version="2.0.8" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+  </ItemGroup>
+</Project>

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Api.UnitTests/Fitnet.Common.Api.UnitTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Api.UnitTests/Fitnet.Common.Api.UnitTests.csproj
@@ -9,11 +9,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Api/Fitnet.Common.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Api/Fitnet.Common.Api.csproj
@@ -5,7 +5,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="11.11.0" />
+      <PackageReference Include="FluentValidation" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Core.UnitTests/Fitnet.Common.Core.UnitTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Core.UnitTests/Fitnet.Common.Core.UnitTests.csproj
@@ -9,11 +9,10 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentAssertions" Version="6.12.2" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-      <PackageReference Include="Shouldly" Version="4.3.0" />
-      <PackageReference Include="xunit" Version="2.9.2" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="Shouldly" />
+      <PackageReference Include="xunit" />
+      <PackageReference Include="xunit.runner.visualstudio">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Core/Fitnet.Common.Core.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Core/Fitnet.Common.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Infrastructure/Fitnet.Common.Infrastructure.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.Infrastructure/Fitnet.Common.Infrastructure.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.4.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0" />
+        <PackageReference Include="MediatR" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/Fitnet.Common.IntegrationTestsToolbox.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/Fitnet.Common.IntegrationTestsToolbox.csproj
@@ -5,22 +5,22 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="35.6.1" />
-        <PackageReference Include="FluentAssertions" Version="6.12.2" />
-        <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-        <PackageReference Include="MassTransit" Version="8.3.2" />
-        <PackageReference Include="Verify.Xunit" Version="28.3.2" />
-        <PackageReference Include="Testcontainers" Version="4.0.0" />
-        <PackageReference Include="Testcontainers.PostgreSql" Version="4.0.0" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.analyzers" Version="1.17.0">
+        <PackageReference Include="Bogus" />
+        <PackageReference Include="JetBrains.Annotations" />
+        <PackageReference Include="MassTransit" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="Verify.Xunit" />
+        <PackageReference Include="Testcontainers" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.analyzers">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit.categories" Version="2.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="xunit.categories" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/EventBus/EventBusAssertions.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Fitnet.Common.IntegrationTestsToolbox/TestEngine/EventBus/EventBusAssertions.cs
@@ -1,10 +1,10 @@
 namespace EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox.TestEngine.EventBus;
 
-using FluentAssertions;
 using MassTransit.Testing;
+using Shouldly;
 
 public static class EventBusAssertions
 {
     public static void EnsureConsumed<TEvent>(this ITestHarness harness) where TEvent : class =>
-        harness.Consumed.Select<TEvent>().Any().Should().BeTrue();
+        harness.Consumed.Select<TEvent>().Any().ShouldBeTrue();
 }

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Directory.Packages.props
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Directory.Packages.props
@@ -1,0 +1,34 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup Label="Production">
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.2.5" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.2.5" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageVersion Include="MassTransit.Abstractions" Version="8.3.2" />
+    <PackageVersion Include="MassTransit" Version="8.3.2" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.2" />
+    <PackageVersion Include="MediatR" Version="12.5.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.4" />
+  </ItemGroup>
+  <ItemGroup Label="Tests">
+    <PackageVersion Include="Bogus" Version="35.6.3" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.analyzers" Version="1.24.0" />
+    <PackageVersion Include="xunit.categories" Version="2.0.8" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+  </ItemGroup>
+</Project>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Api.UnitTests/Fitnet.Contracts.Api.UnitTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Api.UnitTests/Fitnet.Contracts.Api.UnitTests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.analyzers" Version="1.17.0">
+    <PackageReference Include="Bogus" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.categories" Version="2.0.8" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.categories" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Api/Fitnet.Contracts.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Api/Fitnet.Contracts.Api.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
   </ItemGroup>
 
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Fitnet.Contracts.Application.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Application/Fitnet.Contracts.Application.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="3.2.5" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Include="MassTransit.Abstractions" Version="8.3.2" />
-    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" />
+    <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="MassTransit.Abstractions" />
+    <PackageReference Include="MediatR" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fitnet.Contracts.Core\Fitnet.Contracts.Core.csproj" />

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Core.UnitTests/Fitnet.Contracts.Core.UnitTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Core.UnitTests/Fitnet.Contracts.Core.UnitTests.csproj
@@ -5,21 +5,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="35.6.1" />
-        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.analyzers" Version="1.17.0">
+        <PackageReference Include="Bogus" />
+        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.analyzers">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit.categories" Version="2.0.8" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="xunit.categories" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Fitnet.Contracts.Core.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Core/Fitnet.Contracts.Core.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" />
   </ItemGroup>
   
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Fitnet.Contracts.Infrastructure.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.Infrastructure/Fitnet.Contracts.Infrastructure.csproj
@@ -5,13 +5,12 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="MassTransit" Version="8.3.2" />
-    <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.2" />
-    <PackageReference Include="MediatR" Version="12.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0" />
+    <PackageReference Include="MassTransit" />
+    <PackageReference Include="MassTransit.RabbitMQ" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationEvents/Fitnet.Contracts.IntegrationEvents.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts.IntegrationEvents/Fitnet.Contracts.IntegrationEvents.csproj
@@ -4,8 +4,6 @@
     <Version>1.0.7</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.2.5" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Fitnet.Contracts.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Fitnet.Contracts.csproj
@@ -5,9 +5,9 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="3.2.5" />
-        <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+        <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" />
+        <PackageReference Include="JetBrains.Annotations" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Program.cs
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/Fitnet.Contracts/Program.cs
@@ -26,7 +26,7 @@ app.UseErrorHandling();
 app.MapControllers();
 app.RegisterContractsApi();
 
-app.Run();
+await app.RunAsync();
 
 namespace EvolutionaryArchitecture.Fitnet.Contracts
 {

--- a/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/nuget.config
+++ b/Chapter-3-microservice-extraction/Fitnet.Contracts/Src/nuget.config
@@ -7,11 +7,17 @@
     <add key="automatic" value="True" />
   </packageRestore>
   <packageSources>
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <add key="evolutionaryArchitecture" value="https://nuget.pkg.github.com/evolutionary-architecture/index.json" />
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="EvolutionaryArchitecture" value="https://nuget.pkg.github.com/evolutionary-architecture/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="EvolutionaryArchitecture">
+      <package pattern="EvolutionaryArchitecture.*" />
+    </packageSource>
+  </packageSourceMapping>
   <disabledPackageSources />
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
 </configuration>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Directory.Packages.props
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Directory.Packages.props
@@ -3,16 +3,20 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="Production">
-    <PackageVersion Include="MediatR" Version="12.5.0" />
     <PackageVersion Include="Dapper" Version="2.1.66" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.2.5" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.2.5" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.7" />
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="8.3.2" />
     <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageVersion Include="MediatR" Version="12.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
@@ -22,28 +26,24 @@
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.4" />
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.2.5" />
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5" />
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.2.5" />
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup Label="Tests">
     <PackageVersion Include="Bogus" Version="35.6.3" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox" Version="3.2.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.9.0" />
+    <PackageVersion Include="Testcontainers" Version="4.7.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0" />
     <PackageVersion Include="Verify.Xunit" Version="30.17.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="xunit.analyzers" Version="1.24.0" />
     <PackageVersion Include="xunit.categories" Version="2.0.8" />
-    <PackageVersion Include="Testcontainers" Version="4.7.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox" Version="3.2.5" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Directory.Packages.props
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Directory.Packages.props
@@ -8,11 +8,12 @@
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
-    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="8.3.2"/>
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.2"/>
+    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="8.3.2" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9" />
@@ -21,14 +22,14 @@
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.4" />
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.2.5"/>
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5"/>
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.2.5"/>
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.7"/>
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.2.5" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.2.5" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup Label="Tests">
     <PackageVersion Include="Bogus" Version="35.6.3" />
-    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0"/>
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.9.0" />
@@ -42,7 +43,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox" Version="3.2.5"/>
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox" Version="3.2.5" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Directory.Packages.props
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Directory.Packages.props
@@ -20,7 +20,6 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.9" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.4" />
     <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.2.5"/>
     <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5"/>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Directory.Packages.props
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Directory.Packages.props
@@ -1,0 +1,51 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup Label="Production">
+    <PackageVersion Include="MediatR" Version="12.5.0" />
+    <PackageVersion Include="Dapper" Version="2.1.66" />
+    <PackageVersion Include="FluentValidation" Version="12.0.0" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="8.3.2"/>
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.2"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Npgsql" Version="9.0.3" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.9" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.4" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.2.5"/>
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5"/>
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.2.5"/>
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.7"/>
+  </ItemGroup>
+  <ItemGroup Label="Tests">
+    <PackageVersion Include="Bogus" Version="35.6.3" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0"/>
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.9.0" />
+    <PackageVersion Include="Verify.Xunit" Version="30.17.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.analyzers" Version="1.24.0" />
+    <PackageVersion Include="xunit.categories" Version="2.0.8" />
+    <PackageVersion Include="Testcontainers" Version="4.7.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox" Version="3.2.5"/>
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+  </ItemGroup>
+</Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Fitnet.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Fitnet.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
-    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Fitnet.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Fitnet.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0"/>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0"/>
+    <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Fitnet.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Fitnet.csproj
@@ -6,6 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Program.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Fitnet/Program.cs
@@ -38,7 +38,7 @@ app.RegisterPasses(Module.Passes);
 app.RegisterOffers(Module.Offers);
 app.RegisterReports(Module.Reports);
 
-app.Run();
+await app.RunAsync();
 
 namespace EvolutionaryArchitecture.Fitnet
 {

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.Api/Fitnet.Offers.Api.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" Version="3.2.5"/>
+    <PackageReference Include="evolutionaryarchitecture.fitnet.common.core" />
   </ItemGroup>
 
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.DataAccess/Fitnet.Offers.DataAccess.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.DataAccess/Fitnet.Offers.DataAccess.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0"/>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1"/>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.DataAccess/Fitnet.Offers.DataAccess.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Fitnet.Offers.DataAccess/Fitnet.Offers.DataAccess.csproj
@@ -3,6 +3,5 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
-    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
@@ -5,14 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.6.1"/>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="3.2.5"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-    <PackageReference Include="System.Text.Json" Version="9.0.0"/>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0"/>
+    <PackageReference Include="Bogus" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Integrationteststoolbox" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="BouncyCastle.Cryptography" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Offers/Tests/Fitnet.Offers.IntegrationTests/Fitnet.Offers.IntegrationTests.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" />
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Integrationteststoolbox" />
+    <PackageReference Include="BouncyCastle.Cryptography" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
-    <PackageReference Include="BouncyCastle.Cryptography" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="evolutionaryArchitecture.fitnet.common.api" Version="3.2.5"/>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5"/>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" Version="1.0.7"/>
-    <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.3.2"/>
-    <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.2"/>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0"/>
+    <PackageReference Include="evolutionaryArchitecture.fitnet.common.api" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" />
+    <PackageReference Include="MassTransit.EntityFrameworkCore" />
+    <PackageReference Include="MassTransit.RabbitMQ" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="evolutionaryArchitecture.fitnet.common.api" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" />
     <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" />
     <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" />

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
@@ -21,6 +21,5 @@
     <PackageReference Include="MassTransit.EntityFrameworkCore" />
     <PackageReference Include="MassTransit.RabbitMQ" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.DataAccess/Database/Migrations/20250927073029_AddMissingForeignKeys.Designer.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.DataAccess/Database/Migrations/20250927073029_AddMissingForeignKeys.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using EvolutionaryArchitecture.Fitnet.Passes.DataAccess.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace EvolutionaryArchitecture.Fitnet.Migrations
+namespace EvolutionaryArchitecture.Fitnet.Passes.DataAccess.Database.Migrations
 {
     [DbContext(typeof(PassesPersistence))]
-    partial class PassesPersistenceModelSnapshot : ModelSnapshot
+    [Migration("20250927073029_AddMissingForeignKeys")]
+    partial class AddMissingForeignKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.DataAccess/Database/Migrations/20250927073029_AddMissingForeignKeys.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.DataAccess/Database/Migrations/20250927073029_AddMissingForeignKeys.cs
@@ -1,0 +1,47 @@
+﻿#nullable disable
+
+namespace EvolutionaryArchitecture.Fitnet.Passes.DataAccess.Database.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class AddMissingForeignKeys : Migration
+{
+    private static readonly string[] columns = ["InboxMessageId", "InboxConsumerId"];
+    private static readonly string[] principalColumns = ["MessageId", "ConsumerId"];
+
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddForeignKey(
+            name: "FK_OutboxMessage_InboxState_InboxMessageId_InboxConsumerId",
+            schema: "Passes",
+            table: "OutboxMessage",
+            columns: columns,
+            principalSchema: "Passes",
+            principalTable: "InboxState",
+            principalColumns: principalColumns);
+
+        migrationBuilder.AddForeignKey(
+            name: "FK_OutboxMessage_OutboxState_OutboxId",
+            schema: "Passes",
+            table: "OutboxMessage",
+            column: "OutboxId",
+            principalSchema: "Passes",
+            principalTable: "OutboxState",
+            principalColumn: "OutboxId");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_OutboxMessage_InboxState_InboxMessageId_InboxConsumerId",
+            schema: "Passes",
+            table: "OutboxMessage");
+
+        migrationBuilder.DropForeignKey(
+            name: "FK_OutboxMessage_OutboxState_OutboxId",
+            schema: "Passes",
+            table: "OutboxMessage");
+    }
+}

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.DataAccess/Fitnet.Passes.DataAccess.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.DataAccess/Fitnet.Passes.DataAccess.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.3.2"/>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0"/>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1"/>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0"/>
+    <PackageReference Include="MassTransit.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.DataAccess/Fitnet.Passes.DataAccess.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.DataAccess/Fitnet.Passes.DataAccess.csproj
@@ -4,6 +4,5 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
-    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="MassTransit.RabbitMQ" />
-    <PackageReference Include="System.Text.Encodings.Web" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" />
+    <PackageReference Include="MassTransit.RabbitMQ" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Fitnet.Passes.IntegrationEvents/Fitnet.Passes.IntegrationEvents.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.2"/>
-    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-    <PackageReference Include="System.Text.Json" Version="9.0.0"/>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0"/>
+    <PackageReference Include="MassTransit.RabbitMQ" />
+    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.infrastructure" Version="3.2.5"/>
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" />
   </ItemGroup>
 </Project>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
@@ -5,16 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0"/>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.api" Version="3.2.5"/>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="3.2.5"/>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-    <PackageReference Include="System.Text.Json" Version="9.0.0"/>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0"/>
+    <PackageReference Include="BouncyCastle.Cryptography" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/RegisterPass/RegisterPassTests.cs
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Passes/Tests/Fitnet.Passes.IntegrationTests/RegisterPass/RegisterPassTests.cs
@@ -23,7 +23,9 @@ public sealed class RegisterPassTests : IClassFixture<FitnetWebApplicationFactor
     }
 
     [Fact]
+#pragma warning disable S2699
     internal async Task Given_contract_signed_event_Then_should_register_pass()
+#pragma warning restore S2699
     {
         // Arrange
         var @event = ContractSignedEventFaker.Create();

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="MassTransit.RabbitMQ" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Npgsql" />
-    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="EvolutionaryArchitecture.Fitnet.Reports.IntegrationTests"/>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Fitnet.Reports/Fitnet.Reports.csproj
@@ -3,14 +3,14 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.35"/>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" Version="3.2.5"/>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" Version="3.2.5"/>
-    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" Version="3.2.5"/>
-    <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.2"/>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
-    <PackageReference Include="Npgsql" Version="9.0.1"/>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0"/>
+    <PackageReference Include="Dapper" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Api" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Core" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.Infrastructure" />
+    <PackageReference Include="MassTransit.RabbitMQ" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="EvolutionaryArchitecture.Fitnet.Reports.IntegrationTests"/>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
@@ -5,13 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.common.integrationteststoolbox" Version="3.2.5"/>
-    <PackageReference Include="evolutionaryarchitecture.fitnet.contracts.integrationevents" Version="1.0.7"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-    <PackageReference Include="System.Text.Json" Version="9.0.0"/>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0"/>
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox" />
+    <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="BouncyCastle.Cryptography" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/Reports/Tests/Fitnet.Reports.IntegrationTests/Fitnet.Reports.IntegrationTests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="EvolutionaryArchitecture.Fitnet.Common.IntegrationTestsToolbox" />
     <PackageReference Include="EvolutionaryArchitecture.Fitnet.Contracts.IntegrationEvents" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="BouncyCastle.Cryptography" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter-3-microservice-extraction/Fitnet/Src/nuget.config
+++ b/Chapter-3-microservice-extraction/Fitnet/Src/nuget.config
@@ -7,11 +7,17 @@
     <add key="automatic" value="True" />
   </packageRestore>
   <packageSources>
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <add key="evolutionaryArchitecture" value="https://nuget.pkg.github.com/evolutionary-architecture/index.json" />
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="EvolutionaryArchitecture" value="https://nuget.pkg.github.com/evolutionary-architecture/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="EvolutionaryArchitecture">
+      <package pattern="EvolutionaryArchitecture.*" />
+    </packageSource>
+  </packageSourceMapping>
   <disabledPackageSources />
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
 </configuration>


### PR DESCRIPTION
Besides adding central package management to `Fitnet`, `Common` and `Contracts`, I also added a missing migration into `Passes` module that caused errors in integration tests execution.